### PR TITLE
Source candidate deprecation

### DIFF
--- a/sotrplib/maps/maps.py
+++ b/sotrplib/maps/maps.py
@@ -3,8 +3,17 @@ from pathlib import Path
 from typing import Optional
 
 import numpy as np
+from astropy import units as u
+
+# TODO: move photutils utilities to a separate file.
+from photutils.datasets import make_model_image
+from photutils.psf import GaussianPSF
 from pixell import enmap
 from pixell.utils import arcmin, degree
+
+from sotrplib.sources.sources import ForcedPhotometrySource
+
+from ..sims.sim_utils import make_2d_gaussian_model_param_table
 
 
 class Depth1Map:
@@ -979,8 +988,8 @@ def preprocess_map(
 
 def make_model_source_map(
     imap: enmap.ndmap,
-    sources: list,
-    nominal_fwhm_arcmin: float = None,
+    sources: list[ForcedPhotometrySource],
+    nominal_fwhm: u.Quantity | None = None,
     matched_filtered=False,
     verbose=False,
     cuts={},
@@ -1005,29 +1014,24 @@ def make_model_source_map(
     if len(sources) == 0:
         log.warning("make_model_source_map.no_sources", num_sources=0)
         return imap
-    from photutils.datasets import make_model_image
-    from photutils.psf import GaussianPSF
-    from pixell.utils import arcmin, degree
-
-    from ..sims.sim_utils import make_2d_gaussian_model_param_table
 
     if matched_filtered:
-        nominal_fwhm_arcmin *= np.sqrt(2)
+        nominal_fwhm *= np.sqrt(2)
 
-    res_arcmin = abs(imap.wcs.wcs.cdelt[0] * degree / arcmin)
-    log.bind(nominal_fwhm_arcmin=nominal_fwhm_arcmin, res_arcmin=res_arcmin)
+    map_res = abs(imap.wcs.wcs.cdelt[0]) * u.deg
+    log.bind(nominal_fwhm=nominal_fwhm, res=map_res)
     model_params = make_2d_gaussian_model_param_table(
         imap,
         sources,
-        nominal_fwhm_arcmin=nominal_fwhm_arcmin,
+        nominal_fwhm=nominal_fwhm,
         cuts=cuts,
         verbose=verbose,
         log=log,
     )
 
     shape = (
-        int(5 * nominal_fwhm_arcmin / res_arcmin),
-        int(5 * nominal_fwhm_arcmin / res_arcmin),
+        int(5 * nominal_fwhm / map_res),
+        int(5 * nominal_fwhm / map_res),
     )
     log.info("make_model_source_map.make_model_image.start")
     model_map = make_model_image(

--- a/sotrplib/outputs/core.py
+++ b/sotrplib/outputs/core.py
@@ -10,14 +10,14 @@ from pathlib import Path
 
 from sotrplib.maps.core import ProcessableMap
 from sotrplib.sifter.core import SifterResult
-from sotrplib.sources.sources import SourceCandidate
+from sotrplib.sources.sources import ForcedPhotometrySource
 
 
 class SourceOutput(ABC):
     @abstractmethod
     def output(
         self,
-        forced_photometry_candidates: list[SourceCandidate],
+        forced_photometry_candidates: list[ForcedPhotometrySource],
         sifter_result: SifterResult,
         input_map: ProcessableMap,
     ):
@@ -40,7 +40,7 @@ class JSONSerializer(SourceOutput):
 
     def output(
         self,
-        forced_photometry_candidates: list[SourceCandidate],
+        forced_photometry_candidates: list[ForcedPhotometrySource],
         sifter_result: SifterResult,
         input_map: ProcessableMap,
     ):
@@ -72,7 +72,7 @@ class PickleSerializer(SourceOutput):
 
     def output(
         self,
-        forced_photometry_candidates: list[SourceCandidate],
+        forced_photometry_candidates: list[ForcedPhotometrySource],
         sifter_result: SifterResult,
         input_map: ProcessableMap,
     ):

--- a/sotrplib/sifter/core.py
+++ b/sotrplib/sifter/core.py
@@ -14,7 +14,7 @@ from structlog.types import FilteringBoundLogger
 from sotrplib.maps.core import ProcessableMap
 from sotrplib.source_catalog.core import SourceCatalog
 from sotrplib.sources.finding import BlindSourceCandidate
-from sotrplib.sources.sources import ForcedPhotometrySource
+from sotrplib.sources.sources import CrossMatch, ForcedPhotometrySource
 
 
 # TODO: do I want ForcedPhotometrySource here? i.e. would the sifter do the forced photometry?
@@ -82,12 +82,10 @@ class SimpleCatalogSifter(SiftingProvider):
             matches = self.catalog.crossmatch(
                 ra=source.ra, dec=source.dec, radius=self.radius, method=self.method
             )
-            # TODO: convert BlindSearchCandidate to RegisteredSource
+            source = ForcedPhotometrySource.from_blind_source_candidate(source)
+
             if matches:
-                source.update_crossmatches(
-                    match_names=[m.source_id for m in matches],
-                    match_probabilities=[1.0 / len(matches)] * len(matches),
-                )
+                source.crossmatches = [CrossMatch(name=m.source_id) for m in matches]
                 log = log.bind(number_of_matches=len(matches))
                 log = log.info("sifter.simple.matched")
                 source_candidates.append(source)

--- a/sotrplib/sifter/core.py
+++ b/sotrplib/sifter/core.py
@@ -17,6 +17,8 @@ from sotrplib.sources.finding import BlindSourceCandidate
 from sotrplib.sources.sources import ForcedPhotometrySource
 
 
+# TODO: do I want ForcedPhotometrySource here? i.e. would the sifter do the forced photometry?
+# otherwise, the sifter should just take in ForcedPhotometrySources.
 @dataclass
 class SifterResult:
     source_candidates: list[ForcedPhotometrySource]
@@ -80,10 +82,10 @@ class SimpleCatalogSifter(SiftingProvider):
             matches = self.catalog.crossmatch(
                 ra=source.ra, dec=source.dec, radius=self.radius, method=self.method
             )
-
+            # TODO: convert BlindSearchCandidate to RegisteredSource
             if matches:
                 source.update_crossmatches(
-                    match_names=[m.sourceID for m in matches],
+                    match_names=[m.source_id for m in matches],
                     match_probabilities=[1.0 / len(matches)] * len(matches),
                 )
                 log = log.bind(number_of_matches=len(matches))

--- a/sotrplib/sifter/core.py
+++ b/sotrplib/sifter/core.py
@@ -14,21 +14,21 @@ from structlog.types import FilteringBoundLogger
 from sotrplib.maps.core import ProcessableMap
 from sotrplib.source_catalog.core import SourceCatalog
 from sotrplib.sources.finding import BlindSourceCandidate
-from sotrplib.sources.sources import SourceCandidate
+from sotrplib.sources.sources import ForcedPhotometrySource
 
 
 @dataclass
 class SifterResult:
-    source_candidates: list[SourceCandidate]
-    transient_candidates: list[SourceCandidate]
-    noise_candidates: list[SourceCandidate]
+    source_candidates: list[ForcedPhotometrySource]
+    transient_candidates: list[ForcedPhotometrySource]
+    noise_candidates: list[ForcedPhotometrySource]
 
 
 class SiftingProvider(ABC):
     @abstractmethod
     def sift(
         self,
-        sources: list[SourceCandidate],
+        sources: list[BlindSourceCandidate],
         input_map: ProcessableMap,
     ) -> SifterResult:
         raise NotImplementedError
@@ -37,7 +37,7 @@ class SiftingProvider(ABC):
 class EmptySifter(SiftingProvider):
     def sift(
         self,
-        sources: list[SourceCandidate],
+        sources: list[BlindSourceCandidate],
         input_map: ProcessableMap,
     ) -> SifterResult:
         return SifterResult(
@@ -162,7 +162,7 @@ class DefaultSifter(SiftingProvider):
 
     def sift(
         self,
-        sources: list[SourceCandidate],
+        sources: list[BlindSourceCandidate],
         input_map: ProcessableMap,
     ) -> SifterResult:
         from .crossmatch import sift

--- a/sotrplib/sifter/crossmatch.py
+++ b/sotrplib/sifter/crossmatch.py
@@ -13,7 +13,7 @@ from scipy import spatial
 
 from sotrplib.source_catalog.core import SourceCatalog
 
-from ..sources.sources import SourceCandidate
+from ..sources.sources import ForcedPhotometrySource, SourceCandidate
 
 
 def crossmatch_mask(
@@ -105,7 +105,7 @@ def crossmatch_with_million_quasar_catalog(
 
 
 def gaia_match(
-    cand: SourceCandidate,
+    cand: ForcedPhotometrySource,
     maxmag: float = 16,
     maxsep_deg: float = 1 * pixell_utils.degree,
     parallax_required=True,

--- a/sotrplib/sims/sim_maps.py
+++ b/sotrplib/sims/sim_maps.py
@@ -297,7 +297,7 @@ def inject_sources(
     from pixell.utils import arcmin, degree
     from tqdm import tqdm
 
-    from ..sources.sources import SourceCandidate
+    from ..sources.sources import RegisteredSource
     from ..utils.utils import get_fwhm
     from .sim_utils import make_2d_gaussian_model_param_table
 
@@ -351,22 +351,11 @@ def inject_sources(
 
         flux = source.get_flux(source_obs_time)
 
-        inj_source = SourceCandidate(
+        inj_source = RegisteredSource(
             ra=ra,
-            err_ra=0.0,
             dec=dec,
-            err_dec=0.0,
             flux=flux,
-            err_flux=0.0,
-            snr=np.inf,
-            freq=freq,
-            arr=arr if arr else "any",
-            ctime=source_obs_time,
-            fwhm_a=fwhm / arcmin,
-            fwhm_b=fwhm / arcmin,
             source_type="simulated",
-            orientation=0.0,
-            map_id=map_id if map_id else "",
         )
         injected_sources.append(inj_source)
     log.info("inject_sources.sources_to_inject", injected_sources=injected_sources)

--- a/sotrplib/sims/sim_maps.py
+++ b/sotrplib/sims/sim_maps.py
@@ -3,6 +3,10 @@ from datetime import datetime
 import numpy as np
 from pixell import enmap
 
+from sotrplib.sources.forced_photometry import (
+    convert_catalog_to_registered_source_objects,
+)
+
 from ..maps.maps import Depth1Map
 from ..source_catalog.database import SourceCatalogDatabase
 
@@ -147,6 +151,7 @@ def photutils_sim_n_sources(
     arr: str = "sim",
     map_id: str = None,
     ctime: float | enmap.ndmap = None,
+    return_registered_sources: bool = False,
     log=None,
 ):
     """ """
@@ -250,15 +255,20 @@ def photutils_sim_n_sources(
         params,
         imap=sim_map if isinstance(sim_map, enmap.ndmap) else sim_map.flux,
     )
-    injected_sources = convert_catalog_to_source_objects(
-        injected_sources,
-        freq=freq,
-        arr=arr,
-        ctime=ctime,
-        map_id=map_id if map_id else "",
-        source_type="simulated",
-        log=log,
-    )
+    if return_registered_sources:
+        injected_sources = convert_catalog_to_registered_source_objects(
+            injected_sources, source_type="simulated", log=log
+        )
+    else:
+        injected_sources = convert_catalog_to_source_objects(
+            injected_sources,
+            freq=freq,
+            arr=arr,
+            ctime=ctime,
+            map_id=map_id if map_id else "",
+            source_type="simulated",
+            log=log,
+        )
     log.info(
         "photutils_sim_n_sources.sources_injected", n_sources=len(injected_sources)
     )

--- a/sotrplib/sims/sources/core.py
+++ b/sotrplib/sims/sources/core.py
@@ -179,8 +179,9 @@ class RandomSourceSimulation(SourceSimulation):
         self, input_map: ProcessableMap
     ) -> tuple[ProcessableMap, list[RegisteredSource]]:
         noise_map = input_map.noise
+        log = self.log or structlog.get_logger()
 
-        log = self.log.bind(parameters=self.parameters)
+        log = log.bind(parameters=self.parameters)
 
         # TODO: Store the source information as we should be injecting the
         # same sources in all maps in the run.
@@ -196,6 +197,7 @@ class RandomSourceSimulation(SourceSimulation):
             # TODO: Map IDs
             map_id=None,
             ctime=input_map.time_mean,
+            return_registered_sources=True,
             log=log,
         )
 

--- a/sotrplib/sims/sources/core.py
+++ b/sotrplib/sims/sources/core.py
@@ -38,7 +38,7 @@ class ProcessableMapWithSimulatedSources(ProcessableMap):
 
         self.time_first = np.minimum(time, original_map.time_first)
         self.time_mean = time
-        self.time_last = np.maximum(time, original_map.time_first)
+        self.time_end = np.maximum(time, original_map.time_first)
 
         self.original_map = original_map
 

--- a/sotrplib/sims/sources/core.py
+++ b/sotrplib/sims/sources/core.py
@@ -18,7 +18,7 @@ from sotrplib.maps.core import ProcessableMap
 from sotrplib.maps.maps import edge_map
 from sotrplib.sims import sim_maps, sim_sources, sim_utils
 from sotrplib.source_catalog.database import SourceCatalogDatabase
-from sotrplib.sources.sources import SourceCandidate
+from sotrplib.sources.sources import RegisteredSource
 
 
 class ProcessableMapWithSimulatedSources(ProcessableMap):
@@ -70,7 +70,7 @@ class SourceSimulation(ABC):
     @abstractmethod
     def simulate(
         self, input_map: ProcessableMap
-    ) -> tuple[ProcessableMap, list[SourceCandidate]]:
+    ) -> tuple[ProcessableMap, list[RegisteredSource]]:
         """
         Simulate sources on the input map.
 
@@ -96,7 +96,7 @@ class SourceSimulationPassthrough(SourceSimulation):
 
     def simulate(
         self, input_map: ProcessableMap
-    ) -> tuple[ProcessableMap, list[SourceCandidate]]:
+    ) -> tuple[ProcessableMap, list[RegisteredSource]]:
         return input_map, []
 
 
@@ -116,7 +116,7 @@ class DatabaseSourceSimulation(SourceSimulation):
 
     def simulate(
         self, input_map: ProcessableMap
-    ) -> tuple[ProcessableMap, list[SourceCandidate]]:
+    ) -> tuple[ProcessableMap, list[RegisteredSource]]:
         noise_map = input_map.noise
 
         new_flux_map, injected_sources = sim_maps.inject_sources(
@@ -177,7 +177,7 @@ class RandomSourceSimulation(SourceSimulation):
 
     def simulate(
         self, input_map: ProcessableMap
-    ) -> tuple[ProcessableMap, list[SourceCandidate]]:
+    ) -> tuple[ProcessableMap, list[RegisteredSource]]:
         noise_map = input_map.noise
 
         log = self.log.bind(parameters=self.parameters)
@@ -232,7 +232,7 @@ class TransientDatabaseSourceSimulation(SourceSimulation):
 
     def simulate(
         self, input_map: ProcessableMap
-    ) -> tuple[ProcessableMap, list[SourceCandidate]]:
+    ) -> tuple[ProcessableMap, list[RegisteredSource]]:
         noise_map = input_map.noise
 
         log = self.log.bind(transient_database_path=self.transient_database_path)
@@ -297,7 +297,7 @@ class TransientSourceSimulation(SourceSimulation):
 
     def simulate(
         self, input_map: ProcessableMap
-    ) -> tuple[ProcessableMap, list[SourceCandidate]]:
+    ) -> tuple[ProcessableMap, list[RegisteredSource]]:
         noise_map = input_map.noise
 
         log = self.log.bind(parameters=self.parameters)

--- a/sotrplib/source_catalog/core.py
+++ b/sotrplib/source_catalog/core.py
@@ -10,12 +10,12 @@ import numpy as np
 from numpy.typing import NDArray
 from pixell import utils as pixell_utils
 
-from sotrplib.sources.sources import SourceCandidate
+from sotrplib.sources.sources import RegisteredSource
 
 
 class SourceCatalog(ABC):
     @abstractmethod
-    def source_by_id(self, id) -> SourceCandidate:
+    def source_by_id(self, id) -> RegisteredSource:
         """
         Get the information about a source by its internal ID.
         """
@@ -28,20 +28,20 @@ class SourceCatalog(ABC):
         dec: u.Quantity,
         radius: u.Quantity,
         method: Literal["closest", "all"],
-    ) -> list[SourceCandidate]:
+    ) -> list[RegisteredSource]:
         return
 
 
-class SourceCandidateCatalog(SourceCatalog):
+class RegisteredSourceCatalog(SourceCatalog):
     """
-    A source catalog generated purely from a list of 'source candidates',
+    A source catalog generated purely from a list of 'registered sources',
     usually those that are generated as part of the simulation process.
     """
 
-    sources: list[SourceCandidate]
+    sources: list[RegisteredSource]
     ra_dec_array: NDArray
 
-    def __init__(self, sources: list[SourceCandidate]):
+    def __init__(self, sources: list[RegisteredSource]):
         self.sources = sources
 
         # Generate the RA, Dec array for crossmatches.
@@ -56,7 +56,7 @@ class SourceCandidateCatalog(SourceCatalog):
         dec: u.Quantity,
         radius: u.Quantity,
         method: Literal["closest", "all"],
-    ) -> list[SourceCandidate]:
+    ) -> list[RegisteredSource]:
         """
         Get sources within radius of the catalog.
         """
@@ -69,3 +69,9 @@ class SourceCandidateCatalog(SourceCatalog):
         )
 
         return [self.sources[y] for _, y in matches]
+
+
+class SourceCandidateCatalog(SourceCatalog):
+    raise DeprecationWarning(
+        "SourceCandidateCatalog is deprecated, use RegisteredSourceCatalog instead."
+    )

--- a/sotrplib/source_catalog/core.py
+++ b/sotrplib/source_catalog/core.py
@@ -69,9 +69,3 @@ class RegisteredSourceCatalog(SourceCatalog):
         )
 
         return [self.sources[y] for _, y in matches]
-
-
-class SourceCandidateCatalog(SourceCatalog):
-    raise DeprecationWarning(
-        "SourceCandidateCatalog is deprecated, use RegisteredSourceCatalog instead."
-    )

--- a/sotrplib/source_catalog/database.py
+++ b/sotrplib/source_catalog/database.py
@@ -5,7 +5,7 @@ import pandas as pd
 import structlog
 from astropy import units as u
 from astropy.io import fits
-from filelock import FileLock  # Import FileLock and Timeout for file-based locking
+from filelock import FileLock  # Import FileLock for file-based locking
 from pixell.enmap import ndmap
 from socat.client import mock
 from structlog.types import FilteringBoundLogger

--- a/sotrplib/source_catalog/source_catalog.py
+++ b/sotrplib/source_catalog/source_catalog.py
@@ -1,4 +1,6 @@
 from pixell.enmap import enmap
+from structlog import get_logger
+from structlog.types import FilteringBoundLogger
 
 
 class SourceCatalog:
@@ -10,7 +12,7 @@ class SourceCatalog:
 def load_act_catalog(
     source_cat_file: str = "/scratch/gpfs/SIMONSOBS/users/amfoster/depth1_act_maps/inputs/PS_S19_f090_2pass_optimalCatalog.fits",
     flux_threshold: float = 0,
-    log=None,
+    log: FilteringBoundLogger | None = None,
 ):
     """
     source_cat_file is path to source catalog
@@ -21,6 +23,7 @@ def load_act_catalog(
     """
     from astropy.table import Table
 
+    log = log or get_logger()
     log.bind(func_name="load_act_catalog")
     sourcecat = None
     sourcecat = Table.read(source_cat_file)

--- a/sotrplib/sources/blind.py
+++ b/sotrplib/sources/blind.py
@@ -50,26 +50,20 @@ class SigmaClipBlindSearch(BlindSearchProvider):
             raise ValueError(
                 "Input map must be finalized before searching for sources."
             )
-        if input_map.res is None:
+        if input_map.map_resolution is None:
             raise ValueError("Flux map must have a resolution.")
 
-        res_arcmin = input_map.res
-        res_arcmin = res_arcmin.to(u.arcmin)
         self.log.info(
             "sigma_clip_blind_search.searching",
-            res_arcmin=res_arcmin,
             nsigma=self.parameters.sigma_threshold,
-            minrad=[ms.to(u.arcmin).value for ms in self.parameters.minimum_separation],
+            minrad=self.parameters.minimum_separation,
             sigma_thresh_for_minrad=self.parameters.sigma_threshold_for_minimum_separation,
         )
         extracted_sources = extract_sources(
-            input_map.flux,
-            timemap=input_map.time_mean,
-            maprms=abs(input_map.flux / input_map.snr),
+            input_map,
             nsigma=self.parameters.sigma_threshold,
-            minrad=[ms.to(u.arcmin).value for ms in self.parameters.minimum_separation],
+            minrad=self.parameters.minimum_separation,
             sigma_thresh_for_minrad=self.parameters.sigma_threshold_for_minimum_separation,
-            res=res_arcmin.value,
             log=self.log,
         )
         return extracted_sources, []

--- a/sotrplib/sources/blind.py
+++ b/sotrplib/sources/blind.py
@@ -7,14 +7,13 @@ from structlog.types import FilteringBoundLogger
 
 from sotrplib.maps.core import ProcessableMap
 from sotrplib.sources.core import BlindSearchProvider
-from sotrplib.sources.finding import extract_sources
-from sotrplib.sources.sources import BlindSearchSource
+from sotrplib.sources.finding import BlindSourceCandidate, extract_sources
 
 
 class EmptyBlindSearch(BlindSearchProvider):
     def search(
         self, input_map: ProcessableMap
-    ) -> tuple[list[BlindSearchSource], list[enmap.ndmap]]:
+    ) -> tuple[list[BlindSourceCandidate], list[enmap.ndmap]]:
         return [], []
 
 
@@ -45,7 +44,7 @@ class SigmaClipBlindSearch(BlindSearchProvider):
     def search(
         self,
         input_map: ProcessableMap,
-    ) -> tuple[list[BlindSearchSource], list[enmap.ndmap]]:
+    ) -> tuple[list[BlindSourceCandidate], list[enmap.ndmap]]:
         if not input_map.finalized:
             raise ValueError(
                 "Input map must be finalized before searching for sources."

--- a/sotrplib/sources/blind.py
+++ b/sotrplib/sources/blind.py
@@ -8,13 +8,13 @@ from structlog.types import FilteringBoundLogger
 from sotrplib.maps.core import ProcessableMap
 from sotrplib.sources.core import BlindSearchProvider
 from sotrplib.sources.finding import extract_sources
-from sotrplib.sources.sources import SourceCandidate
+from sotrplib.sources.sources import BlindSearchSource
 
 
 class EmptyBlindSearch(BlindSearchProvider):
     def search(
         self, input_map: ProcessableMap
-    ) -> tuple[list[SourceCandidate], list[enmap.ndmap]]:
+    ) -> tuple[list[BlindSearchSource], list[enmap.ndmap]]:
         return [], []
 
 
@@ -45,7 +45,7 @@ class SigmaClipBlindSearch(BlindSearchProvider):
     def search(
         self,
         input_map: ProcessableMap,
-    ) -> tuple[list[SourceCandidate], list[enmap.ndmap]]:
+    ) -> tuple[list[BlindSearchSource], list[enmap.ndmap]]:
         if not input_map.finalized:
             raise ValueError(
                 "Input map must be finalized before searching for sources."

--- a/sotrplib/sources/core.py
+++ b/sotrplib/sources/core.py
@@ -9,9 +9,9 @@ from pixell import enmap
 
 from sotrplib.maps.core import ProcessableMap
 from sotrplib.sources.sources import (
+    BlindSearchSource,
     ForcedPhotometrySource,
     RegisteredSource,
-    SourceCandidate,
 )
 
 
@@ -29,5 +29,5 @@ class BlindSearchProvider(ABC):
     def search(
         self,
         input_map: ProcessableMap,
-    ) -> tuple[list[SourceCandidate], list[enmap.ndmap]]:
+    ) -> tuple[list[BlindSearchSource], list[enmap.ndmap]]:
         return [], []

--- a/sotrplib/sources/core.py
+++ b/sotrplib/sources/core.py
@@ -8,8 +8,8 @@ from abc import ABC, abstractmethod
 from pixell import enmap
 
 from sotrplib.maps.core import ProcessableMap
+from sotrplib.sources.finding import BlindSourceCandidate
 from sotrplib.sources.sources import (
-    BlindSearchSource,
     ForcedPhotometrySource,
     RegisteredSource,
 )
@@ -29,5 +29,5 @@ class BlindSearchProvider(ABC):
     def search(
         self,
         input_map: ProcessableMap,
-    ) -> tuple[list[BlindSearchSource], list[enmap.ndmap]]:
+    ) -> tuple[list[BlindSourceCandidate], list[enmap.ndmap]]:
         return [], []

--- a/sotrplib/sources/finding.py
+++ b/sotrplib/sources/finding.py
@@ -3,8 +3,15 @@ from typing import Any, Union
 
 import numpy as np
 from astropy import units as u
+from astropydantic import AstroPydanticQuantity
+from numpydantic import NDArray
 from photutils.aperture.ellipse import EllipticalAperture
 from pixell.enmap import ndmap
+from structlog import get_logger
+from structlog.types import FilteringBoundLogger
+
+from sotrplib.maps.core import ProcessableMap
+from sotrplib.sources.sources import BlindSearchSource
 
 """
 Source finding routines from spt3g_software.
@@ -18,14 +25,15 @@ def get_source_sky_positions(extracted_sources, skymap):
     from output of extract_sources, use xpeak and ypeak to
     convert to sky coordinates.
     """
-    from pixell.utils import degree
 
     for f in extracted_sources:
         x, y = extracted_sources[f]["xpeak"], extracted_sources[f]["ypeak"]
 
         dec, ra = skymap.pix2sky(np.asarray([[y], [x]]))
-        extracted_sources[f]["ra"] = ra[0] % (360 * degree)
-        extracted_sources[f]["dec"] = dec[0]
+        ra = u.Quantity(ra[0], "rad")
+        dec = u.Quantity(dec[0], "rad")
+        extracted_sources[f]["ra"] = ra % (360 * u.deg)
+        extracted_sources[f]["dec"] = dec
 
         if "err_xpeak" in extracted_sources[f] and "err_ypeak" in extracted_sources[f]:
             dx, dy = (
@@ -33,33 +41,506 @@ def get_source_sky_positions(extracted_sources, skymap):
                 extracted_sources[f]["err_ypeak"],
             )
             ## assume flat sky
-            mapres = abs(skymap.wcs.wcs.cdelt[0]) * degree
-            extracted_sources[f]["err_ra"] = dx * mapres / np.cos(dec[0])
+            mapres = u.Quantity(abs(skymap.wcs.wcs.cdelt[0]), "deg")
+            extracted_sources[f]["err_ra"] = dx * mapres / np.cos(dec)
             extracted_sources[f]["err_dec"] = dy * mapres
 
     return extracted_sources
 
 
-def get_source_observation_time(extracted_sources, timemap: np.ndarray = None):
+def get_source_observation_time(
+    extracted_sources, timemap: ProcessableMap | NDArray = None
+):
     """
     from output of extract_sources, use xpeak and ypeak to
     get the observed time given the map `timemap`.
     """
 
     for f in extracted_sources:
-        if not isinstance(timemap, type(None)):
-            x, y = (
-                int(extracted_sources[f]["xpeak"]),
-                int(extracted_sources[f]["ypeak"]),
-            )
-            extracted_sources[f]["time"] = timemap[y, x]
-        else:
+        if timemap is None:
             extracted_sources[f]["time"] = np.nan
+            continue
+
+        x, y = (
+            int(extracted_sources[f]["xpeak"]),
+            int(extracted_sources[f]["ypeak"]),
+        )
+        if isinstance(timemap, ProcessableMap):
+            t_start = timemap.time_first[y, x]
+            t_mean = timemap.time_mean[y, x]
+            t_end = timemap.time_end[y, x]
+        else:
+            t_mean = timemap[y, x]
+            t_start = np.nan
+            t_end = np.nan
+        # Set the extracted source times, backwards compatibility
+        extracted_sources[f]["time"] = t_mean
+        extracted_sources[f]["time_start"] = t_start
+        extracted_sources[f]["time_end"] = t_end
 
     return extracted_sources
 
 
 def extract_sources(
+    inmap: ProcessableMap,
+    nsigma: float = 5.0,
+    maprms: NDArray | float = None,
+    minrad: list[AstroPydanticQuantity[u.arcmin]] = [u.Quantity(0.5, "arcmin")],
+    sigma_thresh_for_minrad: list[float] = [0.0],
+    pixel_mask: NDArray = None,
+    log: FilteringBoundLogger | None = None,
+) -> list[BlindSearchSource]:
+    log = log or get_logger()
+    log.bind(func_name="extract_sources")
+    if not inmap.finalized:
+        log.error("extract_sources.map_not_finalized")
+        return []
+
+    if len(sigma_thresh_for_minrad) != len(minrad):
+        log.error(
+            "extract_sources.invalid_minrad",
+            minrad=minrad,
+            sigma_thresh_for_minrad=sigma_thresh_for_minrad,
+        )
+        raise ValueError(
+            "If you are specifying multiple avoidance radii,"
+            + "please supply a threshold level for each one."
+        )
+
+    if pixel_mask is not None:
+        inmap.flux *= pixel_mask
+
+    # get rms in map if not supplied
+    if maprms is None:
+        maprms = np.asarray(inmap.flux / inmap.snr)
+        log.bind(map_rms="flux/snr map")
+    else:
+        maprms = maprms
+        log.bind(map_rms=maprms)
+    peaks = find_using_photutils(
+        np.asarray(inmap.flux),
+        maprms,
+        nsigma=nsigma,
+        minnum=2,
+        log=log,
+    )
+
+    npeaks = peaks["n_detected"]
+    log.info("extract_sources.n_detected", npeaks=npeaks)
+    if npeaks == 0:
+        return []
+
+    # gather detected peaks into output structure, ignoring repeat
+    # detections of same object
+    xpeaks = peaks["xcen"]
+    ypeaks = peaks["ycen"]
+    peakvals = peaks["maxvals"]
+    peaksigs = peaks["sigvals"]
+    ellipticities = peaks["ellipticity"]
+    elongations = peaks["elongation"]
+    fwhms = peaks["fwhm"]
+    sigma_major = peaks["semimajor_sigma"]
+    sigma_minor = peaks["semiminor_sigma"]
+    orientation = peaks["orientation"]
+    peak_assoc = np.zeros(npeaks)
+
+    output_struct = dict()
+    for i in np.arange(npeaks):
+        output_struct[i] = {
+            "xpeak": xpeaks[0],
+            "ypeak": ypeaks[0],
+            "peakval": peakvals[0] * inmap.flux_units,
+            "peaksig": peaksigs[0],
+            "ellipticity": ellipticities[0],
+            "elongation": elongations[0],
+            "fwhm": fwhms[0].value * inmap.map_resolution,
+            "semimajor_sigma": sigma_major[0].value * inmap.map_resolution,
+            "semiminor_sigma": sigma_minor[0].value * inmap.map_resolution,
+            "orientation": orientation[0].value * u.deg,
+        }
+
+    minrad_pix = [
+        mr.to(u.rad).value / inmap.map_resolution.to(u.rad).value for mr in minrad
+    ]
+    log.info("extract_sources.output_dict_initialized", minrad_pix=minrad_pix)
+
+    ksource = 1
+    # different accounting if exclusion radius is specified as a function
+    # of significance
+    if len(minrad) > 1:
+        minrad_pix_all = np.zeros(npeaks)
+        sthresh = np.argsort(sigma_thresh_for_minrad)
+        for j in np.arange(len(minrad)):
+            i = sthresh[j]
+            whgthresh = np.where(peaksigs >= sigma_thresh_for_minrad[i])[0]
+            if len(whgthresh) > 0:
+                minrad_pix_all[whgthresh] = minrad_pix[i]
+        minrad_pix_os = np.zeros(npeaks)
+        minrad_pix_os[0] = minrad_pix_all[0]
+        for j in np.arange(npeaks):
+            prev_x = np.array(
+                [output_struct[n]["xpeak"] for n in np.arange(0, ksource)]
+            )
+            prev_y = np.array(
+                [output_struct[n]["ypeak"] for n in np.arange(0, ksource)]
+            )
+            distpix = np.sqrt((prev_x - xpeaks[j]) ** 2 + (prev_y - ypeaks[j]) ** 2)
+            whclose = np.where(distpix <= minrad_pix_os[0:ksource])[0]
+            if len(whclose) == 0:
+                output_struct[ksource] = {
+                    "xpeak": xpeaks[j],
+                    "ypeak": ypeaks[j],
+                    "peakval": peakvals[j] * inmap.flux_units,
+                    "peaksig": peaksigs[j],
+                    "ellipticity": ellipticities[j],
+                    "elongation": elongations[j],
+                    "fwhm": fwhms[j].value * inmap.map_resolution,
+                    "semimajor_sigma": sigma_major[j].value * inmap.map_resolution,
+                    "semiminor_sigma": sigma_minor[j].value * inmap.map_resolution,
+                    "orientation": orientation[j].value * u.deg,
+                }
+
+                peak_assoc[j] = ksource
+                minrad_pix_os[ksource] = minrad_pix_all[j]
+                ksource += 1
+            else:
+                mindist = min(distpix)
+                peak_assoc[j] = distpix.argmin()
+    else:
+        for j in range(npeaks):
+            prev_x = np.array(
+                [output_struct[n]["xpeak"] for n in np.arange(0, ksource)]
+            )
+            prev_y = np.array(
+                [output_struct[n]["ypeak"] for n in np.arange(0, ksource)]
+            )
+            distpix = np.sqrt((prev_x - xpeaks[j]) ** 2 + (prev_y - ypeaks[j]) ** 2)
+            mindist = min(distpix)
+            if mindist > minrad_pix[0]:
+                output_struct[ksource] = {
+                    "xpeak": xpeaks[j],
+                    "ypeak": ypeaks[j],
+                    "peakval": peakvals[j] * inmap.flux_units,
+                    "peaksig": peaksigs[j],
+                    "ellipticity": ellipticities[j],
+                    "elongation": elongations[j],
+                    "fwhm": fwhms[j].value * inmap.map_resolution,
+                    "semimajor_sigma": sigma_major[j].value * inmap.map_resolution,
+                    "semiminor_sigma": sigma_minor[j].value * inmap.map_resolution,
+                    "orientation": orientation[j].value * u.deg,
+                }
+                peak_assoc[j] = ksource
+                ksource += 1
+            else:
+                peak_assoc[j] = distpix.argmin()
+    for src in list(output_struct.keys()):
+        if src >= ksource:
+            del output_struct[src]
+    log.info(
+        "extract_sources.output_dict_prepared",
+        n_sources=len(list(output_struct.keys())),
+    )
+    output_struct = get_source_sky_positions(output_struct, inmap.flux)
+    output_struct = get_source_observation_time(output_struct, inmap)
+    output_data = convert_outstruct_to_blindsearchsources(output_struct)
+    log.info("extract_sources.output_dict_finalized")
+    return output_data
+
+
+@dataclass
+class BlindSourceCandidate:
+    xpeak: float
+    ypeak: float
+    peakval: float
+    peaksig: float
+    ellipticity: u.Quantity
+    elongation: u.Quantity
+    fwhm: u.Quantity
+    semimajor_sigma: float
+    semiminor_sigma: float
+    covar_sigx: float
+    covar_sigy: float
+    covar_sigxy: float
+    orientation: float
+    kron_aperture: EllipticalAperture
+    kron_flux: float
+    kron_fluxerr: float
+    kron_radius: float
+    ra: u.Quantity
+    dec: u.Quantity
+    time: float
+    crossmatch_names: list = field(default_factory=list)
+    crossmatch_probabilities: list = field(default_factory=list)
+    fit_type: str = field(default="blind")
+
+    def update_crossmatches(
+        self,
+        match_names: list,
+        match_probabilities: list = None,
+    ):
+        """
+        Update the crossmatch names and probabilities with new matches.
+        """
+        self.crossmatch_names.extend(match_names)
+        if match_probabilities is not None:
+            self.crossmatch_probabilities.extend(match_probabilities)
+        else:
+            self.crossmatch_probabilities.extend([None] * len(match_names))
+
+        return
+
+
+def convert_blind_source_dictionary_to_models(
+    output_struct: dict[int, dict[str, Any]],
+):
+    models = []
+
+    for struct in output_struct.values():
+        fwhm = struct.pop("fwhm")
+        ra = struct.pop("ra")
+        dec = struct.pop("dec")
+
+        if not isinstance(ra, u.Quantity):
+            ra *= u.rad
+        if not isinstance(dec, u.Quantity):
+            dec *= u.rad
+        if not isinstance(fwhm, u.Quantity):
+            fwhm *= u.arcmin
+
+        models.append(BlindSourceCandidate(ra=ra, dec=dec, fwhm=fwhm))
+
+    return models
+
+
+def convert_outstruct_to_blindsearchsources(
+    output_struct: dict,
+) -> list[BlindSearchSource]:
+    """
+    Convert the output dictionary from extract_sources to BlindSearchSource objects.
+    """
+    outlist = []
+    for struct in output_struct.values():
+        outlist.append(
+            BlindSearchSource(
+                ra=struct.pop("ra"),
+                dec=struct.pop("dec"),
+                err_ra=struct.pop("err_ra", None),
+                err_dec=struct.pop("err_dec", None),
+                flux=struct["peakval"],
+                err_flux=struct["peakval"] / struct["peaksig"],
+                fwhm=struct.pop("fwhm", None),
+                extract_params=struct,
+            )
+        )
+    return outlist
+
+
+def find_using_photutils(
+    Tmap: ndmap,
+    signoise: Union[float, ndmap] = None,
+    minnum: int = 2,
+    nsigma: float = 5.0,
+    log=None,
+):
+    """
+    Written to take same inputs and return outputs in the same format as the
+    function ``find_groups``.  Utilizing astropy.photutils, one can deblend
+    sources close to each other.  Exactly how the deblending is done uses the
+    default arguments of the package, influenced by SExtractor.
+
+    From ``find_groups``: given a 2d array (a map), will find groups of elements
+    (pixels) that are spatially associated (sources).
+
+    Arguments
+    ---------
+    Tmap: enamp.ndmap
+        Intensity map.
+    signoise : float or enmap.ndmap
+        Noise in the map, can be float or enmap.ndmap of same shape as Tmap.
+    offset : float
+        Zero point of map.
+    minnum : int
+        Minimum number of pixels needed to form a group.
+    nsigma : float
+        Required detection threshold for a group.
+
+    Returns
+    -------
+    Dictionary with following keys:
+        * maxvals - array of heights (in map units) of found objects.
+        * sigvals - array of heights (in significance units) of found objects.
+        * xcen - array of x-location of group centers. From the documentation,
+          the "centroid is computed as the center of mass of the unmasked pixels
+          within the source segment."
+        * ycen - array of Y-location of group centers.
+        * semimajor_sigma, semiminor_sigma - sigma in major and minor axes of 2D gauss fit.
+        * orientation - The angle between the x axis and the semimajor axis.
+                        The angle increases in the counter-clockwise direction.
+        * n_detected - Number of detected sources.
+
+    The keys below are outputs of the astropy source finding functionality,
+    being used to test if any of them indicate extendedness of a source.
+        * ellipticity
+        * elongation
+        * fwhm - units of pixels. From the documentation, "circularized FWHM of
+          2D Gaussian function with same second order moments as the source."
+        * kron_aperture
+        * kron_flux - Parameter requires that Tmap already be in units of mJy.
+        * kron_fluxerr - Parameter requires that Tmap already be in units of mJy.
+        * kron_radius - units of pixels.
+
+    Function written by Melanie Archipley, adapted by AF Jan 2025
+    """
+    # this import is here instead of at the beginning because it has strange
+    # dependencies that I (Melanie) do not want to cause problems for other people
+    from photutils import segmentation as pseg
+
+    log.bind(func_name="find_using_photutils")
+    default_keys = {
+        "maxvals": "max_value",
+        "xcen": "xcentroid",
+        "ycen": "ycentroid",
+        "sigvals": None,
+        "n_detected": None,
+    }
+
+    extra_keys = [
+        "ellipticity",
+        "elongation",
+        "fwhm",
+        "semimajor_sigma",
+        "semiminor_sigma",
+        "orientation",
+        "covar_sigx2",
+        "covar_sigy2",
+        "covar_sigxy",
+        "kron_aperture",
+        "kron_flux",
+        "kron_fluxerr",
+        "kron_radius",
+    ]
+
+    groups = {k: 0 for k in list(default_keys) + extra_keys}
+    log.info("find_using_photutils.start")
+    ## convert ndmap to 2D numpy array for photutils
+    Tmap = np.asarray(Tmap)
+    assert len(Tmap.shape) == 2
+    if isinstance(signoise, ndmap):
+        signoise = np.asarray(signoise)
+        assert signoise.shape == Tmap.shape
+
+    img = pseg.detect_sources(Tmap, threshold=nsigma * signoise, npixels=minnum)
+    if img is None:
+        return groups
+
+    img = pseg.deblend_sources(Tmap, img, npixels=minnum)
+    if img is None:
+        return groups
+
+    cat = pseg.SourceCatalog(
+        Tmap,
+        img,
+        error=signoise,
+        apermask_method="correct",
+        kron_params=(2.5, 1.0),
+    )
+
+    # convert catalog to table
+    columns = [v for _, v in default_keys.items() if v] + extra_keys
+    tbl = cat.to_table(columns=columns)
+
+    # rename keys to match find_groups output
+    for k, v in default_keys.items():
+        if v is not None:
+            tbl.rename_column(v, k)
+    tbl.sort("maxvals", reverse=True)
+
+    # store signal at each source location
+    ix, iy = [np.floor(tbl[k] + 0.5).astype(int) for k in ("xcen", "ycen")]
+    tbl["sigvals"] = Tmap[iy, ix] / signoise[iy, ix]
+
+    # populate output dictionary
+    groups["n_detected"] = len(tbl)
+    for k in groups:
+        if k in tbl.columns:
+            groups[k] = tbl[k]
+    log.info("find_using_photutils.end")
+    return groups
+
+
+def mask_sources_outside_map(sourcecat, maskmap: ndmap):
+    """
+    Determines if source is inside mask or observed region
+
+    Args:
+        sourcecat: source catalog, need keys RADeg, decDeg
+        maskmap: ndmap of mask (zero masked, one not masked)
+                 or weights map which will be zero or nan elsewhere.
+
+    Returns:
+        mask column for sources, 1 observed, 0 not observed or outside map
+    """
+    from pixell.enmap import sky2pix
+
+    # Check if sources are in mask
+    coords_rad = np.deg2rad(np.array([sourcecat["decDeg"], sourcecat["RADeg"]]))
+    ypix, xpix = sky2pix(maskmap.shape, maskmap.wcs, coords_rad)
+    mask = np.zeros(len(ypix))
+    for i, (x, y) in enumerate(zip(xpix.astype(int), ypix.astype(int))):
+        if x < 0 or y < 0:
+            m = 0
+        else:
+            try:
+                m = np.nan_to_num(maskmap[y, x])  # lookup mask value
+            except IndexError:
+                m = 0
+        mask[i] = m
+    # Convert to binary
+    ## if non-observed regions are nan, ignore those as well
+    mask[np.abs(mask) > 1e-8] = 1
+    # switch 0 and 1
+    mask = mask.astype("bool")
+
+    return mask
+
+
+def get_ps_inmap(imap: np.ndarray, sourcecat, fluxlim: bool = None):
+    """
+    get point sources in map
+
+    Args:
+        imap:ndmap to get point sources in
+        sourcecat:source catalog
+        fluxlim:flux limit in mJy
+
+    Returns:
+        sourcecat with sources in map
+    """
+    from pixell.enmap import sky2pix
+
+    if fluxlim:
+        sourcecat = sourcecat[sourcecat["fluxJy"] > fluxlim / 1000.0]
+    # convert ra to -180 to 180
+    sourcecat["RADeg"] = np.where(
+        sourcecat["RADeg"] > 180, sourcecat["RADeg"] - 360, sourcecat["RADeg"]
+    )
+
+    sourcecat_coords = sky2pix(
+        imap.shape,
+        imap.wcs,
+        np.array([np.deg2rad(sourcecat["decDeg"]), np.deg2rad(sourcecat["RADeg"])]),
+    )
+    sourcecat = sourcecat[
+        (sourcecat_coords[0] > 0)
+        & (sourcecat_coords[0] < imap.shape[0])
+        & (sourcecat_coords[1] > 0)
+        & (sourcecat_coords[1] < imap.shape[1])
+    ]
+
+    return sourcecat
+
+
+def extract_sources_deprecated(
     inmap: ndmap,
     timemap: ndmap = None,
     maprms: Union[float, ndmap] = None,
@@ -301,273 +782,3 @@ def extract_sources(
     output_data = convert_blind_source_dictionary_to_models(output_struct)
     log.info("extract_sources.output_dict_finalized")
     return output_data
-
-
-@dataclass
-class BlindSourceCandidate:
-    xpeak: float
-    ypeak: float
-    peakval: float
-    peaksig: float
-    ellipticity: u.Quantity
-    elongation: u.Quantity
-    fwhm: u.Quantity
-    semimajor_sigma: float
-    semiminor_sigma: float
-    covar_sigx: float
-    covar_sigy: float
-    covar_sigxy: float
-    orientation: float
-    kron_aperture: EllipticalAperture
-    kron_flux: float
-    kron_fluxerr: float
-    kron_radius: float
-    ra: u.Quantity
-    dec: u.Quantity
-    time: float
-    crossmatch_names: list = field(default_factory=list)
-    crossmatch_probabilities: list = field(default_factory=list)
-    fit_type: str = field(default="blind")
-
-    def update_crossmatches(
-        self,
-        match_names: list,
-        match_probabilities: list = None,
-    ):
-        """
-        Update the crossmatch names and probabilities with new matches.
-        """
-        self.crossmatch_names.extend(match_names)
-        if match_probabilities is not None:
-            self.crossmatch_probabilities.extend(match_probabilities)
-        else:
-            self.crossmatch_probabilities.extend([None] * len(match_names))
-
-        return
-
-
-def convert_blind_source_dictionary_to_models(
-    output_struct: dict[int, dict[str, Any]],
-):
-    models = []
-
-    for struct in output_struct.values():
-        fwhm = struct.pop("fwhm")
-        ra = struct.pop("ra")
-        dec = struct.pop("dec")
-
-        if not isinstance(ra, u.Quantity):
-            ra *= u.rad
-        if not isinstance(dec, u.Quantity):
-            dec *= u.rad
-        if not isinstance(fwhm, u.Quantity):
-            fwhm *= u.arcmin
-
-        models.append(BlindSourceCandidate(**struct, ra=ra, dec=dec, fwhm=fwhm))
-
-    return models
-
-
-def find_using_photutils(
-    Tmap: ndmap,
-    signoise: Union[float, ndmap] = None,
-    minnum: int = 2,
-    nsigma: float = 5.0,
-    log=None,
-):
-    """
-    Written to take same inputs and return outputs in the same format as the
-    function ``find_groups``.  Utilizing astropy.photutils, one can deblend
-    sources close to each other.  Exactly how the deblending is done uses the
-    default arguments of the package, influenced by SExtractor.
-
-    From ``find_groups``: given a 2d array (a map), will find groups of elements
-    (pixels) that are spatially associated (sources).
-
-    Arguments
-    ---------
-    Tmap: enamp.ndmap
-        Intensity map.
-    signoise : float or enmap.ndmap
-        Noise in the map, can be float or enmap.ndmap of same shape as Tmap.
-    offset : float
-        Zero point of map.
-    minnum : int
-        Minimum number of pixels needed to form a group.
-    nsigma : float
-        Required detection threshold for a group.
-
-    Returns
-    -------
-    Dictionary with following keys:
-        * maxvals - array of heights (in map units) of found objects.
-        * sigvals - array of heights (in significance units) of found objects.
-        * xcen - array of x-location of group centers. From the documentation,
-          the "centroid is computed as the center of mass of the unmasked pixels
-          within the source segment."
-        * ycen - array of Y-location of group centers.
-        * semimajor_sigma, semiminor_sigma - sigma in major and minor axes of 2D gauss fit.
-        * orientation - The angle between the x axis and the semimajor axis.
-                        The angle increases in the counter-clockwise direction.
-        * n_detected - Number of detected sources.
-
-    The keys below are outputs of the astropy source finding functionality,
-    being used to test if any of them indicate extendedness of a source.
-        * ellipticity
-        * elongation
-        * fwhm - units of pixels. From the documentation, "circularized FWHM of
-          2D Gaussian function with same second order moments as the source."
-        * kron_aperture
-        * kron_flux - Parameter requires that Tmap already be in units of mJy.
-        * kron_fluxerr - Parameter requires that Tmap already be in units of mJy.
-        * kron_radius - units of pixels.
-
-    Function written by Melanie Archipley, adapted by AF Jan 2025
-    """
-    # this import is here instead of at the beginning because it has strange
-    # dependencies that I (Melanie) do not want to cause problems for other people
-    from photutils import segmentation as pseg
-
-    log.bind(func_name="find_using_photutils")
-    default_keys = {
-        "maxvals": "max_value",
-        "xcen": "xcentroid",
-        "ycen": "ycentroid",
-        "sigvals": None,
-        "n_detected": None,
-    }
-
-    extra_keys = [
-        "ellipticity",
-        "elongation",
-        "fwhm",
-        "semimajor_sigma",
-        "semiminor_sigma",
-        "orientation",
-        "covar_sigx2",
-        "covar_sigy2",
-        "covar_sigxy",
-        "kron_aperture",
-        "kron_flux",
-        "kron_fluxerr",
-        "kron_radius",
-    ]
-
-    groups = {k: 0 for k in list(default_keys) + extra_keys}
-    log.info("find_using_photutils.start")
-    ## convert ndmap to 2D numpy array for photutils
-    Tmap = np.asarray(Tmap)
-    assert len(Tmap.shape) == 2
-    if isinstance(signoise, ndmap):
-        signoise = np.asarray(signoise)
-        assert signoise.shape == Tmap.shape
-
-    img = pseg.detect_sources(Tmap, threshold=nsigma * signoise, npixels=minnum)
-    if img is None:
-        return groups
-
-    img = pseg.deblend_sources(Tmap, img, npixels=minnum)
-    if img is None:
-        return groups
-
-    cat = pseg.SourceCatalog(
-        Tmap,
-        img,
-        error=signoise,
-        apermask_method="correct",
-        kron_params=(2.5, 1.0),
-    )
-
-    # convert catalog to table
-    columns = [v for _, v in default_keys.items() if v] + extra_keys
-    tbl = cat.to_table(columns=columns)
-
-    # rename keys to match find_groups output
-    for k, v in default_keys.items():
-        if v is not None:
-            tbl.rename_column(v, k)
-    tbl.sort("maxvals", reverse=True)
-
-    # store signal at each source location
-    ix, iy = [np.floor(tbl[k] + 0.5).astype(int) for k in ("xcen", "ycen")]
-    tbl["sigvals"] = Tmap[iy, ix] / signoise[iy, ix]
-
-    # populate output dictionary
-    groups["n_detected"] = len(tbl)
-    for k in groups:
-        if k in tbl.columns:
-            groups[k] = tbl[k]
-    log.info("find_using_photutils.end")
-    return groups
-
-
-def mask_sources_outside_map(sourcecat, maskmap: ndmap):
-    """
-    Determines if source is inside mask or observed region
-
-    Args:
-        sourcecat: source catalog, need keys RADeg, decDeg
-        maskmap: ndmap of mask (zero masked, one not masked)
-                 or weights map which will be zero or nan elsewhere.
-
-    Returns:
-        mask column for sources, 1 observed, 0 not observed or outside map
-    """
-    from pixell.enmap import sky2pix
-
-    # Check if sources are in mask
-    coords_rad = np.deg2rad(np.array([sourcecat["decDeg"], sourcecat["RADeg"]]))
-    ypix, xpix = sky2pix(maskmap.shape, maskmap.wcs, coords_rad)
-    mask = np.zeros(len(ypix))
-    for i, (x, y) in enumerate(zip(xpix.astype(int), ypix.astype(int))):
-        if x < 0 or y < 0:
-            m = 0
-        else:
-            try:
-                m = np.nan_to_num(maskmap[y, x])  # lookup mask value
-            except IndexError:
-                m = 0
-        mask[i] = m
-    # Convert to binary
-    ## if non-observed regions are nan, ignore those as well
-    mask[np.abs(mask) > 1e-8] = 1
-    # switch 0 and 1
-    mask = mask.astype("bool")
-
-    return mask
-
-
-def get_ps_inmap(imap: np.ndarray, sourcecat, fluxlim: bool = None):
-    """
-    get point sources in map
-
-    Args:
-        imap:ndmap to get point sources in
-        sourcecat:source catalog
-        fluxlim:flux limit in mJy
-
-    Returns:
-        sourcecat with sources in map
-    """
-    from pixell.enmap import sky2pix
-
-    if fluxlim:
-        sourcecat = sourcecat[sourcecat["fluxJy"] > fluxlim / 1000.0]
-    # convert ra to -180 to 180
-    sourcecat["RADeg"] = np.where(
-        sourcecat["RADeg"] > 180, sourcecat["RADeg"] - 360, sourcecat["RADeg"]
-    )
-
-    sourcecat_coords = sky2pix(
-        imap.shape,
-        imap.wcs,
-        np.array([np.deg2rad(sourcecat["decDeg"]), np.deg2rad(sourcecat["RADeg"])]),
-    )
-    sourcecat = sourcecat[
-        (sourcecat_coords[0] > 0)
-        & (sourcecat_coords[0] < imap.shape[0])
-        & (sourcecat_coords[1] > 0)
-        & (sourcecat_coords[1] < imap.shape[1])
-    ]
-
-    return sourcecat

--- a/sotrplib/sources/force.py
+++ b/sotrplib/sources/force.py
@@ -65,17 +65,18 @@ class SimpleForcedPhotometry(ForcedPhotometryProvider):
 class Scipy2DGaussianFitter(ForcedPhotometryProvider):
     sources: list[RegisteredSource]
     flux_limit_centroid: u.Quantity  ## this should probably not exist within the function; i.e. be decided before handing the list to the provider.
-    plot: bool
     reproject_thumbnails: bool
     log: FilteringBoundLogger
 
     def __init__(
         self,
+        sources: list[RegisteredSource] = [],
         flux_limit_centroid: u.Quantity = u.Quantity(0.3, "Jy"),
         reproject_thumbnails: bool = False,
         thumbnail_half_width: u.Quantity = u.Quantity(0.25, "deg"),
         log: FilteringBoundLogger | None = None,
     ):
+        self.sources = sources
         self.flux_limit_centroid = flux_limit_centroid
         self.reproject_thumbnails = reproject_thumbnails
         self.thumbnail_half_width = thumbnail_half_width
@@ -91,7 +92,7 @@ class Scipy2DGaussianFitter(ForcedPhotometryProvider):
 
         fit_sources = scipy_2d_gaussian_fit(
             input_map,
-            sources,
+            self.sources + sources,
             flux_lim_fit_centroid=self.flux_limit_centroid,
             thumbnail_half_width=self.thumbnail_half_width,
             fwhm=fwhm,

--- a/sotrplib/sources/force.py
+++ b/sotrplib/sources/force.py
@@ -90,7 +90,7 @@ class Scipy2DGaussianFitter(ForcedPhotometryProvider):
         )
 
         fit_sources = scipy_2d_gaussian_fit(
-            input_map.flux,
+            input_map,
             sources,
             flux_lim_fit_centroid=self.flux_limit_centroid,
             thumbnail_half_width=self.thumbnail_half_width,

--- a/sotrplib/sources/force.py
+++ b/sotrplib/sources/force.py
@@ -35,8 +35,10 @@ class SimpleForcedPhotometry(ForcedPhotometryProvider):
     def __init__(
         self,
         mode: Literal["spline", "nn"],
+        log: FilteringBoundLogger | None = None,
     ):
         self.mode = mode
+        self.log = log or get_logger()
 
     def force(
         self,
@@ -45,7 +47,7 @@ class SimpleForcedPhotometry(ForcedPhotometryProvider):
     ):
         # Implement the single pixel forced photometry ("nn" is much faster than "spline")
         ## see https://github.com/simonsobs/pixell/blob/master/pixell/utils.py#L542
-
+        out_sources = []
         for source in sources:
             flux = input_map.flux.at(
                 [source.dec.to_value(u.rad), source.ra.to_value(u.rad)], mode=self.mode
@@ -53,13 +55,15 @@ class SimpleForcedPhotometry(ForcedPhotometryProvider):
             snr = input_map.snr.at(
                 [source.dec.to_value(u.rad), source.ra.to_value(u.rad)], mode=self.mode
             )
-            source.flux = AstroPydanticQuantity(u.Quantity(flux, input_map.flux_units))
-            source.err_flux = AstroPydanticQuantity(
-                u.Quantity(flux / snr, input_map.flux_units)
+            out_source = ForcedPhotometrySource(
+                **source.model_dump(),
+                fit_method="nearest_neighbor" if self.mode == "nn" else "spline",
             )
-            source.fit_method = "nearest_neighbor" if self.mode == "nn" else "spline"
+            out_source.flux = AstroPydanticQuantity(flux, u.Jy)
+            out_source.err_flux = AstroPydanticQuantity(flux / snr, u.Jy)
+            out_sources.append(out_source)
 
-        return sources
+        return out_sources
 
 
 class Scipy2DGaussianFitter(ForcedPhotometryProvider):

--- a/sotrplib/sources/force.py
+++ b/sotrplib/sources/force.py
@@ -8,7 +8,10 @@ from structlog.types import FilteringBoundLogger
 
 from sotrplib.maps.core import ProcessableMap
 from sotrplib.sources.core import ForcedPhotometryProvider
-from sotrplib.sources.forced_photometry import photutils_2D_gauss_fit
+from sotrplib.sources.forced_photometry import (
+    curve_fit_2d_gaussian,
+    photutils_2D_gauss_fit,
+)
 from sotrplib.sources.sources import ForcedPhotometrySource, RegisteredSource
 from sotrplib.utils.utils import get_fwhm
 
@@ -57,6 +60,69 @@ class SimpleForcedPhotometry(ForcedPhotometryProvider):
             source.fit_method = "nearest_neighbor" if self.mode == "nn" else "spline"
 
         return sources
+
+
+class Scipy2DGaussianFitter(ForcedPhotometryProvider):
+    sources: list[RegisteredSource]
+    flux_limit_centroid: u.Quantity  ## this should probably not exist within the function; i.e. be decided before handing the list to the provider.
+    plot: bool
+    reproject_thumbnails: bool
+    log: FilteringBoundLogger
+
+    def __init__(
+        self,
+        sources: list[RegisteredSource],
+        flux_limit_centroid: u.Quantity = u.Quantity(0.3, "Jy"),
+        plot: bool = False,
+        reproject_thumbnails: bool = False,
+        log: FilteringBoundLogger | None = None,
+    ):
+        self.sources = sources
+        self.flux_limit_centroid = flux_limit_centroid
+        self.plot = plot
+        self.reproject_thumbnails = reproject_thumbnails
+        self.log = log or get_logger()
+
+    def force(
+        self, input_map: ProcessableMap, sources: list[RegisteredSource]
+    ) -> list[ForcedPhotometrySource]:
+        # TODO: refactor get_fwhm as part of the ProcessableMap
+        fwhm = u.Quantity(
+            get_fwhm(freq=input_map.frequency, arr=input_map.array), "arcmin"
+        )
+
+        size_deg = fwhm.to_value("degree")
+        fwhm_arcmin = fwhm.to_value("arcmin")
+
+        sources, thumbnails = curve_fit_2d_gaussian(
+            flux_map=input_map.flux,
+            snr_map=input_map.snr,
+            source_catalog=self.sources + sources,
+            flux_lim_fit_centroid=self.flux_limit_centroid.to_value("Jy"),
+            size_deg=size_deg,
+            fwhm_arcmin=fwhm_arcmin,
+            PLOT=self.plot,
+            reproject_thumb=self.reproject_thumbnails,
+            return_thumbnails=self.return_thumbnails,
+            debug=True,
+            log=self.log,
+        )
+        ## workaround until photutils_2D_gauss_fit reutrns forcedphotometry sources.
+        ## convert the sourcecatalog to list of forcedphotometry sources
+        rs: list[ForcedPhotometrySource] = []
+        for i in range(len(sources["fluxJy"])):
+            rsi = ForcedPhotometrySource(
+                ra=sources["RADeg"][i] * u.deg,
+                dec=sources["decDeg"][i] * u.deg,
+                flux=sources["fluxJy"][i] * u.Jy,
+            )
+            if thumbnails:
+                rsi.thumbnail = np.asarray(thumbnails[i])
+                rsi.thumbnail_res = input_map.map_resolution
+                rsi.thumbnail_unit = input_map.flux_units
+
+            rs.append(rsi)
+        return rs
 
 
 class PhotutilsGaussianFitter(ForcedPhotometryProvider):

--- a/sotrplib/sources/force.py
+++ b/sotrplib/sources/force.py
@@ -9,8 +9,8 @@ from structlog.types import FilteringBoundLogger
 from sotrplib.maps.core import ProcessableMap
 from sotrplib.sources.core import ForcedPhotometryProvider
 from sotrplib.sources.forced_photometry import (
-    curve_fit_2d_gaussian,
     photutils_2D_gauss_fit,
+    scipy_2d_gaussian_fit,
 )
 from sotrplib.sources.sources import ForcedPhotometrySource, RegisteredSource
 from sotrplib.utils.utils import get_fwhm
@@ -71,16 +71,14 @@ class Scipy2DGaussianFitter(ForcedPhotometryProvider):
 
     def __init__(
         self,
-        sources: list[RegisteredSource],
         flux_limit_centroid: u.Quantity = u.Quantity(0.3, "Jy"),
-        plot: bool = False,
         reproject_thumbnails: bool = False,
+        thumbnail_half_width: u.Quantity = u.Quantity(0.25, "deg"),
         log: FilteringBoundLogger | None = None,
     ):
-        self.sources = sources
         self.flux_limit_centroid = flux_limit_centroid
-        self.plot = plot
         self.reproject_thumbnails = reproject_thumbnails
+        self.thumbnail_half_width = thumbnail_half_width
         self.log = log or get_logger()
 
     def force(
@@ -91,38 +89,17 @@ class Scipy2DGaussianFitter(ForcedPhotometryProvider):
             get_fwhm(freq=input_map.frequency, arr=input_map.array), "arcmin"
         )
 
-        size_deg = fwhm.to_value("degree")
-        fwhm_arcmin = fwhm.to_value("arcmin")
-
-        sources, thumbnails = curve_fit_2d_gaussian(
-            flux_map=input_map.flux,
-            snr_map=input_map.snr,
-            source_catalog=self.sources + sources,
-            flux_lim_fit_centroid=self.flux_limit_centroid.to_value("Jy"),
-            size_deg=size_deg,
-            fwhm_arcmin=fwhm_arcmin,
-            PLOT=self.plot,
+        fit_sources = scipy_2d_gaussian_fit(
+            input_map.flux,
+            sources,
+            flux_lim_fit_centroid=self.flux_limit_centroid,
+            thumbnail_half_width=self.thumbnail_half_width,
+            fwhm=fwhm,
             reproject_thumb=self.reproject_thumbnails,
-            return_thumbnails=self.return_thumbnails,
-            debug=True,
             log=self.log,
         )
-        ## workaround until photutils_2D_gauss_fit reutrns forcedphotometry sources.
-        ## convert the sourcecatalog to list of forcedphotometry sources
-        rs: list[ForcedPhotometrySource] = []
-        for i in range(len(sources["fluxJy"])):
-            rsi = ForcedPhotometrySource(
-                ra=sources["RADeg"][i] * u.deg,
-                dec=sources["decDeg"][i] * u.deg,
-                flux=sources["fluxJy"][i] * u.Jy,
-            )
-            if thumbnails:
-                rsi.thumbnail = np.asarray(thumbnails[i])
-                rsi.thumbnail_res = input_map.map_resolution
-                rsi.thumbnail_unit = input_map.flux_units
 
-            rs.append(rsi)
-        return rs
+        return fit_sources
 
 
 class PhotutilsGaussianFitter(ForcedPhotometryProvider):

--- a/sotrplib/sources/forced_photometry.py
+++ b/sotrplib/sources/forced_photometry.py
@@ -176,7 +176,8 @@ class Gaussian2DFitter:
                 theta_err,
                 offset_err,
             ) = perr
-            dec_fit, ra_fit = self.data.pix2sky([y0, x0]) * u.rad
+            dec_fit = y0 * self.map_resolution
+            ra_fit = x0 * np.cos(dec_fit.to(u.rad).value) * self.map_resolution
             dec_offset = dec_fit - self.thumbnail_center[1]
             ra_offset = ra_fit - self.thumbnail_center[0]
             if ra_offset > 180.0 * u.deg:
@@ -223,7 +224,7 @@ def scipy_2d_gaussian_fit(
     log: FilteringBoundLogger | None = None,
 ) -> list[ForcedPhotometrySource]:
     """ """
-
+    log = log or get_logger()
     log = log.bind(func_name="scipy_2d_gaussian_fit")
     preamble = "sources.fitting.scipy_2d_gaussian_fit."
     fit_method = "2d_gaussian"

--- a/sotrplib/sources/forced_photometry.py
+++ b/sotrplib/sources/forced_photometry.py
@@ -1,6 +1,7 @@
 from typing import Union
 
 import numpy as np
+import structlog
 from astropy import units as u
 from astropydantic import AstroPydanticQuantity, AstroPydanticUnit
 from numpy.typing import ArrayLike
@@ -634,7 +635,7 @@ def convert_catalog_to_registered_source_objects(
     of RegisteredSource objects.
 
     """
-
+    log = log or structlog.get_logger()
     log = log.bind(func_name="convert_catalog_to_registered_source_objects")
 
     if isinstance(catalog_sources, list):
@@ -661,10 +662,10 @@ def convert_catalog_to_registered_source_objects(
             source_id=catalog_sources["name"][i],
             source_type=source_type,
         )
-
-        if catalog_sources["ra_offset_arcmin"][i]:
-            cs.err_ra = catalog_sources["err_ra_offset_arcmin"][i] * u.arcmin
-            cs.err_dec = catalog_sources["err_dec_offset_arcmin"][i] * u.arcmin
+        if "ra_offset_arcmin" in catalog_sources:
+            if catalog_sources["ra_offset_arcmin"][i]:
+                cs.err_ra = catalog_sources["err_ra_offset_arcmin"][i] * u.arcmin
+                cs.err_dec = catalog_sources["err_dec_offset_arcmin"][i] * u.arcmin
 
         cs.add_crossmatch(
             CrossMatch(

--- a/sotrplib/sources/forced_photometry.py
+++ b/sotrplib/sources/forced_photometry.py
@@ -31,7 +31,7 @@ class GaussianFitParameters(BaseModel):
     theta_err: AstroPydanticQuantity[u.deg] | None = None
     forced_center: bool | None = None
     failed: bool = False
-    failure_reasons: list[str] | None = None
+    failure_reason: str | None = None
 
 
 def gaussian_2d(
@@ -153,6 +153,8 @@ class Gaussian2DFitter:
             )
         except RuntimeError:
             self.log.error("curve_fit_2d_gaussian.curve_fit.failed")
+            self.fit_params.failed = True
+            self.fit_params.failure_reason = "curve_fit_runtime_error"
             return
 
         self.log.debug("curve_fit_2d_gaussian.curve_fit.success", popt=popt)

--- a/sotrplib/sources/sources.py
+++ b/sotrplib/sources/sources.py
@@ -82,13 +82,20 @@ class ForcedPhotometrySource(RegisteredSource):
     """
 
     err_flux: AstroPydanticQuantity[u.mJy] | None = None
+    offset_ra: AstroPydanticQuantity[u.deg] | None = None
+    offset_dec: AstroPydanticQuantity[u.deg] | None = None
     fwhm_ra: AstroPydanticQuantity[u.deg] | None = None
     fwhm_dec: AstroPydanticQuantity[u.deg] | None = None
+    err_fwhm_ra: AstroPydanticQuantity[u.deg] | None = None
+    err_fwhm_dec: AstroPydanticQuantity[u.deg] | None = None
     fit_method: Literal["2d_gaussian", "nearest_neighbor", "spline"] = "2d_gaussian"
     fit_params: dict | None = None
+    fit_failed: bool = False
+    fit_failure_reason: str | None = None
     thumbnail: NDArray | None = None
     thumbnail_res: AstroPydanticQuantity[u.arcmin] | None = None
     thumbnail_unit: AstroPydanticUnit | None = None
+
     _log: FilteringBoundLogger = PrivateAttr(default_factory=structlog.get_logger)
 
     def extract_thumbnail(

--- a/sotrplib/sources/sources.py
+++ b/sotrplib/sources/sources.py
@@ -23,6 +23,7 @@ class CrossMatch(BaseModel):
     probability: float | None = None
     distance: AstroPydanticQuantity[u.deg] | None = None
     flux: AstroPydanticQuantity[u.mJy] | None = None
+    err_flux: AstroPydanticQuantity[u.mJy] | None = None
     frequency: AstroPydanticQuantity[u.GHz] | None = None
     catalog_name: str | None = None
     catalog_idx: int | None = None
@@ -48,6 +49,7 @@ class RegisteredSource(BaseSource):
     extended: bool | None = None
     err_ra: AstroPydanticQuantity[u.deg] | None = None
     err_dec: AstroPydanticQuantity[u.deg] | None = None
+    err_flux: AstroPydanticQuantity[u.mJy] | None = None
     _log: FilteringBoundLogger = PrivateAttr(default_factory=structlog.get_logger)
 
     def add_crossmatch(self, crossmatch: CrossMatch):
@@ -141,6 +143,7 @@ class BlindSearchSource(BaseSource):
     These don't a priori have a catalog counterpart.
     """
 
+    source_id: str | None = None
     err_flux: AstroPydanticQuantity[u.mJy] | None = None
     err_ra: AstroPydanticQuantity[u.deg] | None = None
     err_dec: AstroPydanticQuantity[u.deg] | None = None

--- a/sotrplib/sources/sources.py
+++ b/sotrplib/sources/sources.py
@@ -204,8 +204,8 @@ class SourceCandidate(BaseModel):
         """
         return ForcedPhotometrySource(
             source_id=self.sourceID,
-            flux=u.Quantity(self.flux, "mJy"),
-            err_flux=u.Quantity(self.err_flux, "mJy"),
+            flux=u.Quantity(self.flux, "Jy"),
+            err_flux=u.Quantity(self.err_flux, "Jy"),
             ra=u.Quantity(self.ra, "deg"),
             dec=u.Quantity(self.dec, "deg"),
             err_ra=u.Quantity(self.err_ra, "deg"),

--- a/sotrplib/sources/sources.py
+++ b/sotrplib/sources/sources.py
@@ -39,7 +39,9 @@ class RegisteredSource(BaseSource):
     """
 
     source_id: str | None = None
-    source_type: Literal["extragalactic", "star", "asteroid", "unknown"] | None = None
+    source_type: (
+        Literal["extragalactic", "star", "asteroid", "simulated", "unknown"] | None
+    ) = None
 
     crossmatches: list[CrossMatch] | None = None
 

--- a/sotrplib/sources/subtractor.py
+++ b/sotrplib/sources/subtractor.py
@@ -5,7 +5,7 @@ Source subtraction steps.
 from abc import ABC, abstractmethod
 
 from sotrplib.maps.core import ProcessableMap
-from sotrplib.sources.sources import SourceCandidate
+from sotrplib.sources.sources import ForcedPhotometrySource, SourceCandidate
 
 
 class SourceSubtractedMap(ProcessableMap):
@@ -16,7 +16,9 @@ class SourceSubtractedMap(ProcessableMap):
 class SourceSubtractor(ABC):
     @abstractmethod
     def subtract(
-        self, sources: list[SourceCandidate], input_map: ProcessableMap
+        self,
+        sources: list[SourceCandidate] | list[ForcedPhotometrySource],
+        input_map: ProcessableMap,
     ) -> SourceSubtractedMap:
         return
 
@@ -27,6 +29,8 @@ class EmptySourceSubtractor(SourceSubtractor):
     """
 
     def subtract(
-        self, sources: list[SourceCandidate], input_map: ProcessableMap
+        self,
+        sources: list[SourceCandidate] | list[ForcedPhotometrySource],
+        input_map: ProcessableMap,
     ) -> ProcessableMap:
         return input_map

--- a/tests/test_forced_photometry/test_forced_photometry.py
+++ b/tests/test_forced_photometry/test_forced_photometry.py
@@ -1,6 +1,14 @@
 import pytest
+from astropy import units as u
 
-from sotrplib.sources.force import EmptyForcedPhotometry, SimpleForcedPhotometry
+from sotrplib.sources.force import (
+    EmptyForcedPhotometry,
+    Scipy2DGaussianFitter,
+    SimpleForcedPhotometry,
+)
+
+### sources returned from simulations need to be converted to registered sources
+### for now, they have implied flux units of Jy
 
 
 def test_simple_forced_photometry(map_with_single_source):
@@ -16,7 +24,7 @@ def test_simple_forced_photometry(map_with_single_source):
     )
 
     assert len(results) == 1
-    assert results[0].flux.value == pytest.approx(sources[0].flux, rel=2e-1)
+    assert results[0].flux.to(u.Jy).value == pytest.approx(sources[0].flux, rel=2e-1)
     assert results[0].fit_method == "nearest_neighbor"
 
 
@@ -27,3 +35,15 @@ def test_empty_forced_photometry(map_with_single_source):
     results = forced_photometry.force(input_map=input_map, sources=sources)
 
     assert results == []
+
+
+def test_scipy_curve_fit(map_with_single_source):
+    input_map, sources = map_with_single_source
+
+    forced_photometry = Scipy2DGaussianFitter()
+    results = forced_photometry.force(
+        input_map=input_map, sources=[s.to_forced_photometry_source() for s in sources]
+    )
+    assert len(results) == 1
+    assert results[0].flux.to(u.Jy).value == pytest.approx(sources[0].flux, rel=2e-1)
+    assert results[0].fit_method == "2d_gaussian"

--- a/tests/test_forced_photometry/test_forced_photometry.py
+++ b/tests/test_forced_photometry/test_forced_photometry.py
@@ -45,5 +45,14 @@ def test_scipy_curve_fit(map_with_single_source):
         input_map=input_map, sources=[s.to_forced_photometry_source() for s in sources]
     )
     assert len(results) == 1
+    if results[0].fit_failed:
+        assert results[0].fit_failure_reason == "source_near_map_edge"
+        while results[0].fit_failed:
+            input_map, sources = map_with_single_source
+            results = forced_photometry.force(
+                input_map=input_map,
+                sources=[s.to_forced_photometry_source() for s in sources],
+            )
+
     assert results[0].flux.to(u.Jy).value == pytest.approx(sources[0].flux, rel=2e-1)
     assert results[0].fit_method == "2d_gaussian"

--- a/tests/test_forced_photometry/test_forced_photometry.py
+++ b/tests/test_forced_photometry/test_forced_photometry.py
@@ -19,12 +19,12 @@ def test_simple_forced_photometry(map_with_single_source):
     results = forced_photometry.force(input_map=input_map, sources=[])
     assert results == []
 
-    results = forced_photometry.force(
-        input_map=input_map, sources=[s.to_forced_photometry_source() for s in sources]
-    )
+    results = forced_photometry.force(input_map=input_map, sources=sources)
 
     assert len(results) == 1
-    assert results[0].flux.to(u.Jy).value == pytest.approx(sources[0].flux, rel=2e-1)
+    assert results[0].flux.to(u.Jy).value == pytest.approx(
+        sources[0].flux.to(u.Jy).value, rel=2e-1
+    )
     assert results[0].fit_method == "nearest_neighbor"
 
 
@@ -41,18 +41,19 @@ def test_scipy_curve_fit(map_with_single_source):
     input_map, sources = map_with_single_source
 
     forced_photometry = Scipy2DGaussianFitter()
-    results = forced_photometry.force(
-        input_map=input_map, sources=[s.to_forced_photometry_source() for s in sources]
-    )
+    results = forced_photometry.force(input_map=input_map, sources=sources)
     assert len(results) == 1
+    ntries = 10
     if results[0].fit_failed:
         assert results[0].fit_failure_reason == "source_near_map_edge"
-        while results[0].fit_failed:
-            input_map, sources = map_with_single_source
+        while results[0].fit_failed and ntries > 0:
             results = forced_photometry.force(
                 input_map=input_map,
-                sources=[s.to_forced_photometry_source() for s in sources],
+                sources=sources,
             )
+            ntries -= 1
 
-    assert results[0].flux.to(u.Jy).value == pytest.approx(sources[0].flux, rel=2e-1)
+    assert results[0].flux.to(u.Jy).value == pytest.approx(
+        sources[0].flux.to(u.Jy).value, rel=2e-1
+    )
     assert results[0].fit_method == "2d_gaussian"

--- a/tests/test_sims/conftest.py
+++ b/tests/test_sims/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from astropy import units as u
 
 
 @pytest.fixture
@@ -47,9 +48,9 @@ def dummy_source():
     from sotrplib.sims.sim_sources import SimTransient
 
     ds = SimTransient()
-    ds.ra = 0.4
-    ds.dec = -0.4
-    ds.flux = 1.0
+    ds.ra = 0.4 * u.deg
+    ds.dec = -0.4 * u.deg
+    ds.flux = 1.0 * u.Jy
     ds.peak_time = 0.0
     ds.flare_width = 1.0
     return ds

--- a/tests/test_sims/test_sim_maps.py
+++ b/tests/test_sims/test_sim_maps.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from astropy import units as u
 from pixell import enmap
 from structlog import get_logger
 
@@ -133,20 +134,20 @@ def test_inject_sources_empty_and_not_flaring(sim_map_params, dummy_source, log=
 def test_inject_sources_out_of_bounds(sim_map_params, dummy_source, log=log):
     test_map = sim_maps.make_enmap(**sim_map_params["maps"], log=log)
     # Place source out of bounds
-    dummy_source.ra = 999.0
-    dummy_source.dec = 999.0
+    dummy_source.ra = 999.0 * u.deg
+    dummy_source.dec = 999.0 * u.deg
     _, injected = sim_maps.inject_sources(test_map, [dummy_source], 0.0, log=log)
     assert injected == []
 
 
 def test_inject_sources_nan_mapval(sim_map_params, dummy_source, log=log):
-    from pixell.utils import degree
-
     test_map = sim_maps.make_enmap(**sim_map_params["maps"], log=log)
     # Set a pixel to nan and inject source there
-    dummy_source.ra = sim_map_params["maps"]["center_ra"]
-    dummy_source.dec = sim_map_params["maps"]["center_dec"]
-    x, y = test_map.sky2pix([dummy_source.dec * degree, dummy_source.ra * degree])
+    dummy_source.ra = sim_map_params["maps"]["center_ra"] * u.deg
+    dummy_source.dec = sim_map_params["maps"]["center_dec"] * u.deg
+    x, y = test_map.sky2pix(
+        [dummy_source.dec.to(u.rad).value, dummy_source.ra.to(u.rad).value]
+    )
     test_map[int(x), int(y)] = np.nan
     _, injected = sim_maps.inject_sources(test_map, [dummy_source], 0.0, log=log)
     assert injected == []

--- a/tests/test_sims/test_sim_source_injection.py
+++ b/tests/test_sims/test_sim_source_injection.py
@@ -1,7 +1,6 @@
 import pytest
+from astropy import units as u
 from pixell import enmap
-
-# from .conftest import sim_map_params, dummy_source
 from structlog import get_logger
 
 from sotrplib.sims import sim_maps
@@ -85,8 +84,6 @@ def test_inject_sources_bad_maptype(log=log):
 
 
 def test_inject_sources_out_of_bounds(sim_map_params, dummy_source, log=log):
-    from pixell.utils import degree
-
     test_map = sim_maps.make_enmap(**sim_map_params["maps"], log=log)
     oob_source = dummy_source
     center_ra, center_dec = (
@@ -95,8 +92,8 @@ def test_inject_sources_out_of_bounds(sim_map_params, dummy_source, log=log):
     )
     ra_width = test_map.shape[-2] * test_map.wcs.wcs.cdelt[0] * 60  # arcmin
     dec_width = test_map.shape[-1] * test_map.wcs.wcs.cdelt[1] * 60  # arcmin
-    oob_source.ra = (center_ra + ra_width) / degree  # Out of bounds
-    oob_source.dec = (center_dec + dec_width) / degree  # Out of bounds
+    oob_source.ra = (center_ra + ra_width) * u.deg  # Out of bounds
+    oob_source.dec = (center_dec + dec_width) * u.deg  # Out of bounds
     _, injected = sim_maps.inject_sources(test_map, [oob_source], 0.0, log=log)
     assert injected == []
 
@@ -105,8 +102,8 @@ def test_inject_sources_not_flaring(sim_map_params, dummy_source, log=log):
     test_map = sim_maps.make_enmap(**sim_map_params["maps"], log=log)
     # observation_time far from peak_time
     quiescent_source = dummy_source
-    quiescent_source.ra = sim_map_params["maps"]["center_ra"]
-    quiescent_source.dec = sim_map_params["maps"]["center_dec"]
+    quiescent_source.ra = sim_map_params["maps"]["center_ra"] * u.deg
+    quiescent_source.dec = sim_map_params["maps"]["center_dec"] * u.deg
     ## inject source with width 1. but 10 days after peak time
     _, injected = sim_maps.inject_sources(test_map, [quiescent_source], 10.0, log=log)
     assert injected == []

--- a/tests/test_sims/test_sim_utils.py
+++ b/tests/test_sims/test_sim_utils.py
@@ -1,4 +1,5 @@
 import pytest
+from astropy import units as u
 from structlog import get_logger
 
 log = get_logger()
@@ -102,9 +103,9 @@ def test_read_write_transients_db(tmp_path, sim_transient_params, log=log):
     transients = []
     for _ in range(sim_transient_params["injected_transients"]["n_transients"]):
         transient = SimTransient()
-        transient.ra = 0
-        transient.dec = 0
-        transient.flux = 1
+        transient.ra = 0 * u.deg
+        transient.dec = 0 * u.deg
+        transient.flux = 1 * u.Jy
         transient.peak_time = 1.5e9
         transient.flare_width = 1.0
         transients.append(transient)

--- a/tests/test_simulation_pipeline/test_pipeline.py
+++ b/tests/test_simulation_pipeline/test_pipeline.py
@@ -115,7 +115,7 @@ def test_find_sources_blind(
 
     # Crossmatches should, well, match
     source_ids = sorted([x.source_id for x in sources[:32]])
-    match_ids = sorted([x.crossmatch_names[0] for x in res.source_candidates])
+    match_ids = sorted([x.crossmatches[0].name for x in res.source_candidates])
 
     assert source_ids == match_ids
 

--- a/tests/test_simulation_pipeline/test_pipeline.py
+++ b/tests/test_simulation_pipeline/test_pipeline.py
@@ -9,14 +9,14 @@ from sotrplib.handlers.basic import PipelineRunner
 from sotrplib.outputs.core import PickleSerializer
 from sotrplib.sifter.core import SimpleCatalogSifter
 from sotrplib.sims.maps import SimulatedMap
-from sotrplib.source_catalog.core import SourceCandidateCatalog
+from sotrplib.source_catalog.core import RegisteredSourceCatalog
 from sotrplib.sources.blind import SigmaClipBlindSearch
 from sotrplib.sources.force import PhotutilsGaussianFitter, Scipy2DGaussianFitter
 from sotrplib.sources.forced_photometry import (
     photutils_2D_gauss_fit,
     scipy_2d_gaussian_fit,
 )
-from sotrplib.sources.sources import RegisteredSource, SourceCandidate
+from sotrplib.sources.sources import RegisteredSource
 
 
 def test_created_map(empty_map: SimulatedMap):
@@ -65,7 +65,9 @@ def test_basic_pipeline_scipy(
     runner.run()
 
 
-def test_injected_sources(map_with_sources: tuple[SimulatedMap, list[SourceCandidate]]):
+def test_injected_sources(
+    map_with_sources: tuple[SimulatedMap, list[RegisteredSource]],
+):
     new_map, sources = map_with_sources
 
     assert new_map.finalized
@@ -86,7 +88,7 @@ def test_injected_sources(map_with_sources: tuple[SimulatedMap, list[SourceCandi
 
 
 def test_basic_pipeline(
-    tmp_path, map_with_sources: tuple[SimulatedMap, list[SourceCandidate]]
+    tmp_path, map_with_sources: tuple[SimulatedMap, list[RegisteredSource]]
 ):
     """
     Tests a complete setup of the basic pipeline run.
@@ -110,7 +112,7 @@ def test_basic_pipeline(
 
 
 def test_find_single_source_blind(
-    map_with_single_source: tuple[SimulatedMap, list[SourceCandidate]],
+    map_with_single_source: tuple[SimulatedMap, list[RegisteredSource]],
 ):
     """
     Tests that we can find a set of sources that we just injected with
@@ -126,7 +128,7 @@ def test_find_single_source_blind(
 
     # Check we can sift them out!
     sifter = SimpleCatalogSifter(
-        catalog=SourceCandidateCatalog(sources=sources),
+        catalog=RegisteredSourceCatalog(sources=sources),
         radius=u.Quantity(30.0, "arcsec"),
     )
 
@@ -137,7 +139,7 @@ def test_find_single_source_blind(
 
 
 def test_find_sources_blind(
-    map_with_sources: tuple[SimulatedMap, list[SourceCandidate]],
+    map_with_sources: tuple[SimulatedMap, list[RegisteredSource]],
 ):
     """
     Tests that we can find a set of sources that we just injected with
@@ -153,8 +155,8 @@ def test_find_sources_blind(
 
     # Check we can sift them out!
     sifter = SimpleCatalogSifter(
-        catalog=SourceCandidateCatalog(sources=sources[:32]),
-        radius=u.Quantity(0.5, "arcsec"),
+        catalog=RegisteredSourceCatalog(sources=sources[:32]),
+        radius=u.Quantity(0.5, "arcmin"),
         method="closest",
     )
 

--- a/tests/test_simulation_pipeline/test_pipeline.py
+++ b/tests/test_simulation_pipeline/test_pipeline.py
@@ -2,7 +2,6 @@
 Tests for the fully simulated pipeline setup.
 """
 
-import structlog
 from astropy import units as u
 
 from sotrplib.handlers.basic import PipelineRunner
@@ -13,7 +12,6 @@ from sotrplib.source_catalog.core import RegisteredSourceCatalog
 from sotrplib.sources.blind import SigmaClipBlindSearch
 from sotrplib.sources.force import Scipy2DGaussianFitter
 from sotrplib.sources.forced_photometry import (
-    photutils_2D_gauss_fit,
     scipy_2d_gaussian_fit,
 )
 from sotrplib.sources.sources import RegisteredSource
@@ -62,28 +60,6 @@ def test_basic_pipeline_scipy(
     )
 
     runner.run()
-
-
-def test_injected_sources(
-    map_with_sources: tuple[SimulatedMap, list[RegisteredSource]],
-):
-    new_map, sources = map_with_sources
-
-    assert new_map.finalized
-    assert len(sources) > 0
-
-    # See if we can recover them
-    fits, thumbnails = photutils_2D_gauss_fit(
-        flux_map=new_map.flux,
-        snr_map=new_map.snr,
-        source_catalog=sources,
-        log=structlog.get_logger(),
-        return_thumbnails=True,
-    )
-
-    # Can't look at length of fits because the fits
-    # are skipped for items near the edge.
-    assert len(thumbnails) == len(sources)
 
 
 def test_find_single_source_blind(

--- a/tests/test_source_catalog/test_source_catalog.py
+++ b/tests/test_source_catalog/test_source_catalog.py
@@ -5,11 +5,9 @@ Testing source catalog generation and usage.
 import astropy.units as u
 import pytest
 
-from sotrplib.source_catalog.core import SourceCandidateCatalog
+from sotrplib.source_catalog.core import RegisteredSourceCatalog
 from sotrplib.source_catalog.database import MockDatabase
-from sotrplib.sources.sources import (
-    SourceCandidate,
-)
+from sotrplib.sources.sources import RegisteredSource
 
 
 @pytest.fixture
@@ -55,33 +53,23 @@ def test_socat_mock_db(dummy_socat_db):
 
 
 def test_simple_source_catalog():
-    outside_source = SourceCandidate(
-        ra=10.0,
-        dec=10.0,
-        err_ra=0.0,
-        err_dec=0.0,
-        flux=10.0,
-        err_flux=0.1,
-        snr=10.0,
-        freq="f090",
-        ctime=12345.0,
-        arr="pa5",
+    outside_source = RegisteredSource(
+        ra=10.0 * u.deg,
+        dec=10.0 * u.deg,
+        err_ra=0.0 * u.deg,
+        err_dec=0.0 * u.deg,
+        flux=10.0 * u.Jy,
     )
 
-    inside_source = SourceCandidate(
-        ra=20.0,
-        dec=20.0,
-        err_ra=0.0,
-        err_dec=0.0,
-        flux=10.0,
-        err_flux=0.1,
-        snr=10.0,
-        freq="f090",
-        ctime=12345.0,
-        arr="pa5",
+    inside_source = RegisteredSource(
+        ra=20.0 * u.deg,
+        dec=20.0 * u.deg,
+        err_ra=0.0 * u.deg,
+        err_dec=0.0 * u.deg,
+        flux=10.0 * u.Jy,
     )
 
-    catalog = SourceCandidateCatalog(sources=[outside_source, inside_source])
+    catalog = RegisteredSourceCatalog(sources=[outside_source, inside_source])
 
     match = catalog.crossmatch(
         ra=20.1 * u.deg, dec=20.1 * u.deg, radius=2.0 * u.deg, method="all"


### PR DESCRIPTION
Try to deprecate all uses of SourceCandidate. Prefer ForcedPhotometrySource or RegisteredSource where applicable.

still have a BlindSourceCandidate dataclass in finding.py which is an intermediate between the photutils blind search output and the ForcedPhotometrySource class.