### PR TITLE
Sifter config

### DIFF
--- a/scripts/historical_lightcurve_extractor/collate_lightcurves.py
+++ b/scripts/historical_lightcurve_extractor/collate_lightcurves.py
@@ -63,6 +63,12 @@ P.add_argument(
     default=False,
     help="Dont cleanup the initial lc_dir.",
 )
+P.add_argument(
+    "--overwrite",
+    action="store_true",
+    default=False,
+    help="Overwrite output files if they exist.",
+)
 
 
 def collate_lightcurve_files(lc_files, out_file, cleanup=True):
@@ -75,7 +81,7 @@ def collate_lightcurve_files(lc_files, out_file, cleanup=True):
                 inlines.append(line)
 
     headerlines = 0
-    with open(out_file, "w") as f:
+    with open(out_file, "a" if not args.overwrite else "w") as f:
         for i in range(len(inlines)):
             if "#" in inlines[i]:
                 headerlines += 1

--- a/sotrplib/config/sifter.py
+++ b/sotrplib/config/sifter.py
@@ -4,7 +4,8 @@ from typing import Literal
 from pydantic import BaseModel
 from structlog.types import FilteringBoundLogger
 
-from sotrplib.sifter.core import EmptySifter, SiftingProvider
+from sotrplib.sifter.core import DefaultSifter, EmptySifter, SiftingProvider
+from sotrplib.sources.sources import RegisteredSource
 
 
 class SifterConfig(BaseModel, ABC):
@@ -22,4 +23,15 @@ class EmptySifterConfig(SifterConfig):
         return EmptySifter()
 
 
-AllSifterConfigTypes = EmptySifterConfig
+class DefaultSifterConfig(SifterConfig):
+    sifter_type: Literal["default"] = "default"
+    catalog_sources: list[RegisteredSource] | None = None
+
+    def to_sifter(self, log: FilteringBoundLogger | None = None) -> SiftingProvider:
+        return DefaultSifter(
+            catalog_sources=self.catalog_sources,
+            log=log,
+        )
+
+
+AllSifterConfigTypes = (EmptySifterConfig, DefaultSifterConfig)

--- a/sotrplib/handlers/basic.py
+++ b/sotrplib/handlers/basic.py
@@ -66,7 +66,7 @@ class PipelineRunner:
                 sources=forced_photometry_candidates, input_map=input_map
             )
 
-            blind_sources = self.blind_search.search(input_map=source_subtracted_map)
+            blind_sources, _ = self.blind_search.search(input_map=source_subtracted_map)
 
             # Should we be passing the source subtracted map or the original to the sifter..?
             sifter_result = self.sifter.sift(blind_sources, input_map)

--- a/sotrplib/sifter/core.py
+++ b/sotrplib/sifter/core.py
@@ -14,7 +14,7 @@ from structlog.types import FilteringBoundLogger
 
 from sotrplib.maps.core import ProcessableMap
 from sotrplib.source_catalog.core import SourceCatalog
-from sotrplib.sources.sources import CrossMatch, MeasuredSource
+from sotrplib.sources.sources import CrossMatch, MeasuredSource, RegisteredSource
 
 
 @dataclass
@@ -102,7 +102,7 @@ class SimpleCatalogSifter(SiftingProvider):
 
 
 class DefaultSifter(SiftingProvider):
-    catalog_sources: list
+    catalog_sources: list[RegisteredSource]
     "the list of sources to match against with this sifter"
     radius_1Jy: AstroPydanticQuantity[u.Jy]
     "matching radius for a 1Jy source, arcmin"
@@ -127,17 +127,11 @@ class DefaultSifter(SiftingProvider):
 
     def __init__(
         self,
-        catalog_sources: list,
-        radius_1Jy: AstroPydanticQuantity[u.arcmin] = AstroPydanticQuantity(30.0, "arcmin"),
-        min_match_radius: AstroPydanticQuantity[u.arcmin] = AstroPydanticQuantity(
-            1.5, "arcmin"
-        ),
-        ra_jitter: AstroPydanticQuantity[u.arcmin] = AstroPydanticQuantity(
-            0.0, "arcmin"
-        ),
-        dec_jitter: AstroPydanticQuantity[u.arcmin] = AstroPydanticQuantity(
-            0.0, "arcmin"
-        ),
+        catalog_sources: list[RegisteredSource],
+        radius_1Jy: u.Quantity = u.Quantity(30.0, "arcmin"),
+        min_match_radius: u.Quantity = u.Quantity(1.5, "arcmin"),
+        ra_jitter: u.Quantity = u.Quantity(0.0, "arcmin"),
+        dec_jitter: u.Quantity = u.Quantity(0.0, "arcmin"),
         cuts: dict[str, list[float]] | None = None,
         crossmatch_with_gaia: bool = True,
         crossmatch_with_million_quasar: bool = True,

--- a/sotrplib/sifter/core.py
+++ b/sotrplib/sifter/core.py
@@ -128,7 +128,7 @@ class DefaultSifter(SiftingProvider):
     def __init__(
         self,
         catalog_sources: list,
-        radius_1Jy: AstroPydanticQuantity[u.Jy] = AstroPydanticQuantity(30.0, "arcmin"),
+        radius_1Jy: AstroPydanticQuantity[u.arcmin] = AstroPydanticQuantity(30.0, "arcmin"),
         min_match_radius: AstroPydanticQuantity[u.arcmin] = AstroPydanticQuantity(
             1.5, "arcmin"
         ),

--- a/sotrplib/sources/finding.py
+++ b/sotrplib/sources/finding.py
@@ -258,6 +258,25 @@ def convert_outstruct_to_measured_source_objects(
         ms = MeasuredSource(**struct)
         ms.measurement_type = "blind"
         ms.frequency = get_frequency(inmap.frequency) if inmap else None
+        ms.flux = struct["peakval"]
+        ms.err_flux = struct["peakval"] / struct["peaksig"]
+        ms.snr = struct["peaksig"]
+
+        sigma_maj = struct["semimajor_sigma"]
+        sigma_min = struct["semiminor_sigma"]
+        theta = struct["orientation"].to(u.rad).value
+        sigma_ra = np.sqrt(
+            sigma_maj**2 * np.cos(theta) ** 2 + sigma_min**2 * np.sin(theta) ** 2
+        )
+        sigma_dec = np.sqrt(
+            sigma_maj**2 * np.sin(theta) ** 2 + sigma_min**2 * np.cos(theta) ** 2
+        )
+        ms.err_ra = sigma_ra
+        ms.err_dec = sigma_dec
+        # convert to FWHM
+        k = 2.0 * np.sqrt(2.0 * np.log(2.0))  # ≈ 2.354820045
+        ms.fwhm_ra = k * sigma_ra
+        ms.fwhm_dec = k * sigma_dec
         outlist.append(ms)
     return outlist
 

--- a/sotrplib/sources/sources.py
+++ b/sotrplib/sources/sources.py
@@ -86,6 +86,7 @@ class MeasuredSource(RegisteredSource):
 
     """
 
+    snr: float | None = None
     offset_ra: AstroPydanticQuantity[u.deg] | None = None
     offset_dec: AstroPydanticQuantity[u.deg] | None = None
     fwhm_ra: AstroPydanticQuantity[u.deg] | None = None

--- a/tests/test_simulation_pipeline/test_pipeline.py
+++ b/tests/test_simulation_pipeline/test_pipeline.py
@@ -52,7 +52,7 @@ def test_basic_pipeline_scipy(
         forced_photometry=Scipy2DGaussianFitter(sources=sources),
         source_subtractor=None,
         blind_search=SigmaClipBlindSearch(),
-        sifter=None,
+        sifter=DefaultSifter(catalog_sources=sources),
         outputs=[PickleSerializer(directory=tmp_path)],
     )
 


### PR DESCRIPTION
Add the default sifter to the configuration and test the use of it in test_pipeline

Sifter now takes two lists of sources. The catalog sources should be RegisteredSource type (i.e. they're registered in the catalog and have at least one crossmatch w/ that catalog) and the blind search sources that you want to crossmatch are MeasuredSource objects.

The output of the sifter is a SifterResult object which is a set of three lists of MeasuredSources ; source_candidates, transient_candidates, and noise_candidates


Should probably change the name of "source_candidates" to something like "catalog_matches" but that's just a variable name.