### PR TITLE
Load catalog json

### DIFF
--- a/sample_read_map.json
+++ b/sample_read_map.json
@@ -12,16 +12,16 @@
     ],
     "forced_photometry_catalog":
         {
-            "catalog_type": "mock_forced_photometry",
+            "catalog_type": "mock_socat",
             "db_path": "/scratch/gpfs/SIMONSOBS/users/amfoster/depth1_act_maps/inputs/PS_S19_f090_2pass_optimalCatalog.fits",
             "flux_lower_limit": 0.3,
-            "flux_units": "mJy"
+            "flux_units": "Jy"
         },
     "source_catalogs": [
         {
-            "catalog_type": "mock_act",
+            "catalog_type": "mock_socat",
             "db_path": "/scratch/gpfs/SIMONSOBS/users/amfoster/depth1_act_maps/inputs/PS_S19_f090_2pass_optimalCatalog.fits",
-            "flux_lower_limit": 0.03,
+            "flux_lower_limit": 0.01,
             "flux_units": "Jy"
         }
     ],

--- a/sample_read_map.json
+++ b/sample_read_map.json
@@ -10,6 +10,21 @@
             "flux_units": "mJy"
         }
     ],
+    "forced_photometry_catalog":
+        {
+            "catalog_type": "mock_forced_photometry",
+            "db_path": "/scratch/gpfs/SIMONSOBS/users/amfoster/depth1_act_maps/inputs/PS_S19_f090_2pass_optimalCatalog.fits",
+            "flux_lower_limit": 0.3,
+            "flux_units": "mJy"
+        },
+    "source_catalogs": [
+        {
+            "catalog_type": "mock_act",
+            "db_path": "/scratch/gpfs/SIMONSOBS/users/amfoster/depth1_act_maps/inputs/PS_S19_f090_2pass_optimalCatalog.fits",
+            "flux_lower_limit": 0.03,
+            "flux_units": "Jy"
+        }
+    ],
     "preprocessors": [
         {
             "preprocessor_type": "kappa_rho"

--- a/sotrplib/config/config.py
+++ b/sotrplib/config/config.py
@@ -5,6 +5,10 @@ import structlog
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from sotrplib.config.source_catalog import (
+    AllSourceCatalogConfigTypes,
+    EmptySourceCatalogConfig,
+)
 from sotrplib.config.source_simulation import AllSourceSimulationConfigTypes
 from sotrplib.handlers.basic import PipelineRunner
 
@@ -28,6 +32,14 @@ class Settings(BaseSettings):
 
     maps: list[AllMapConfigTypes] = []
     "Input maps"
+
+    forced_photometry_catalog: AllSourceCatalogConfigTypes = Field(
+        default_factory=EmptySourceCatalogConfig
+    )
+    "Catalogs to use for forced photometry"
+
+    source_catalogs: list[AllSourceCatalogConfigTypes] = []
+    "Source catalogs to use"
 
     preprocessors: list[AllPreprocessorConfigTypes] = []
     "Map pre-processors"
@@ -73,6 +85,14 @@ class Settings(BaseSettings):
 
         contents = {
             "maps": [x.to_map(log=log) for x in self.maps],
+            "forced_photometry_catalog": self.forced_photometry_catalog.to_source_catalog(
+                log=log
+            )
+            if self.forced_photometry_catalog
+            else None,
+            "source_catalogs": [
+                x.to_source_catalog(log=log) for x in self.source_catalogs
+            ],
             "preprocessors": [x.to_preprocessor(log=log) for x in self.preprocessors],
             "postprocessors": [
                 x.to_postprocessor(log=log) for x in self.postprocessors

--- a/sotrplib/config/source_catalog.py
+++ b/sotrplib/config/source_catalog.py
@@ -1,0 +1,70 @@
+from abc import ABC, abstractmethod
+from typing import Literal
+
+from astropy import units as u
+from pydantic import BaseModel
+from structlog.types import FilteringBoundLogger
+
+from sotrplib.source_catalog.database import (
+    MockACTDatabase,
+    MockDatabase,
+    MockForcedPhotometryDatabase,
+)
+
+
+class SourceCatalogConfig(BaseModel, ABC):
+    catalog_type: str
+
+    @abstractmethod
+    def to_source_catalog(
+        self, log: FilteringBoundLogger | None = None
+    ) -> MockDatabase:
+        return
+
+
+class EmptySourceCatalogConfig(SourceCatalogConfig):
+    catalog_type: Literal["empty"] = "empty"
+
+    def to_source_catalog(
+        self, log: FilteringBoundLogger | None = None
+    ) -> MockDatabase:
+        return MockDatabase(log=log)
+
+
+class MockACTSourceCatalogConfig(SourceCatalogConfig):
+    catalog_type: Literal["mock_act"] = "mock_act"
+    db_path: str | None = None
+    flux_lower_limit: float = 0.03
+    flux_units: str = "Jy"
+
+    def to_source_catalog(
+        self, log: FilteringBoundLogger | None = None
+    ) -> MockACTDatabase:
+        return MockACTDatabase(
+            db_path=self.db_path,
+            flux_lower_limit=u.Quantity(self.flux_lower_limit, self.flux_units),
+            log=log,
+        )
+
+
+class MockForcedPhotometrySourceCatalogConfig(SourceCatalogConfig):
+    catalog_type: Literal["mock_forced_photometry"] = "mock_forced_photometry"
+    db_path: str | None = None
+    flux_lower_limit: float = 0.3
+    flux_units: str = "Jy"
+
+    def to_source_catalog(
+        self, log: FilteringBoundLogger | None = None
+    ) -> MockForcedPhotometryDatabase:
+        return MockForcedPhotometryDatabase(
+            db_path=self.db_path,
+            flux_lower_limit=u.Quantity(self.flux_lower_limit, self.flux_units),
+            log=log,
+        )
+
+
+AllSourceCatalogConfigTypes = (
+    EmptySourceCatalogConfig
+    | MockACTSourceCatalogConfig
+    | MockForcedPhotometrySourceCatalogConfig
+)

--- a/sotrplib/config/source_catalog.py
+++ b/sotrplib/config/source_catalog.py
@@ -8,7 +8,6 @@ from structlog.types import FilteringBoundLogger
 from sotrplib.source_catalog.database import (
     MockACTDatabase,
     MockDatabase,
-    MockForcedPhotometryDatabase,
 )
 
 
@@ -31,8 +30,8 @@ class EmptySourceCatalogConfig(SourceCatalogConfig):
         return MockDatabase(log=log)
 
 
-class MockACTSourceCatalogConfig(SourceCatalogConfig):
-    catalog_type: Literal["mock_act"] = "mock_act"
+class MockSourceCatalogConfig(SourceCatalogConfig):
+    catalog_type: Literal["mock_socat"] = "mock_socat"
     db_path: str | None = None
     flux_lower_limit: float = 0.03
     flux_units: str = "Jy"
@@ -47,24 +46,4 @@ class MockACTSourceCatalogConfig(SourceCatalogConfig):
         )
 
 
-class MockForcedPhotometrySourceCatalogConfig(SourceCatalogConfig):
-    catalog_type: Literal["mock_forced_photometry"] = "mock_forced_photometry"
-    db_path: str | None = None
-    flux_lower_limit: float = 0.3
-    flux_units: str = "Jy"
-
-    def to_source_catalog(
-        self, log: FilteringBoundLogger | None = None
-    ) -> MockForcedPhotometryDatabase:
-        return MockForcedPhotometryDatabase(
-            db_path=self.db_path,
-            flux_lower_limit=u.Quantity(self.flux_lower_limit, self.flux_units),
-            log=log,
-        )
-
-
-AllSourceCatalogConfigTypes = (
-    EmptySourceCatalogConfig
-    | MockACTSourceCatalogConfig
-    | MockForcedPhotometrySourceCatalogConfig
-)
+AllSourceCatalogConfigTypes = EmptySourceCatalogConfig | MockSourceCatalogConfig

--- a/sotrplib/handlers/basic.py
+++ b/sotrplib/handlers/basic.py
@@ -9,6 +9,7 @@ from sotrplib.maps.preprocessor import MapPreprocessor
 from sotrplib.outputs.core import SourceOutput
 from sotrplib.sifter.core import EmptySifter, SiftingProvider
 from sotrplib.sims.sources.core import SourceSimulation
+from sotrplib.source_catalog.database import MockDatabase
 from sotrplib.sources.blind import EmptyBlindSearch
 from sotrplib.sources.core import BlindSearchProvider, ForcedPhotometryProvider
 from sotrplib.sources.force import EmptyForcedPhotometry
@@ -19,6 +20,8 @@ class PipelineRunner:
     def __init__(
         self,
         maps: list[ProcessableMap],
+        forced_photometry_catalog: MockDatabase | None,
+        source_catalogs: list[MockDatabase] | None,
         preprocessors: list[MapPreprocessor] | None,
         postprocessors: list[MapPostprocessor] | None,
         source_simulators: list[SourceSimulation] | None,
@@ -29,6 +32,8 @@ class PipelineRunner:
         outputs: list[SourceOutput] | None,
     ):
         self.maps = maps
+        self.forced_photometry_catalog = forced_photometry_catalog
+        self.source_catalogs = source_catalogs or []
         self.preprocessors = preprocessors or []
         self.postprocessors = postprocessors or []
         self.source_simulators = source_simulators or []
@@ -52,7 +57,15 @@ class PipelineRunner:
             for postprocessor in self.postprocessors:
                 postprocessor.postprocess(input_map=input_map)
 
+            crossmatch_catalog = []
+            for catalog in self.source_catalogs:
+                crossmatch_catalog.extend(catalog.cat.get_all_sources())
+
             for_forced_photometry = []
+            if self.forced_photometry_catalog:
+                for_forced_photometry.extend(
+                    self.forced_photometry_catalog.cat.get_all_sources()
+                )
 
             for simulator in self.source_simulators:
                 input_map, additional_sources = simulator.simulate(input_map=input_map)
@@ -68,8 +81,8 @@ class PipelineRunner:
 
             blind_sources, _ = self.blind_search.search(input_map=source_subtracted_map)
 
-            # Should we be passing the source subtracted map or the original to the sifter..?
-            sifter_result = self.sifter.sift(blind_sources, input_map)
+            self.sifter.catalog_sources = crossmatch_catalog
+            sifter_result = self.sifter.sift(blind_sources, source_subtracted_map)
 
             for output in self.outputs:
                 output.output(

--- a/sotrplib/handlers/basic.py
+++ b/sotrplib/handlers/basic.py
@@ -59,12 +59,12 @@ class PipelineRunner:
 
             crossmatch_catalog = []
             for catalog in self.source_catalogs:
-                crossmatch_catalog.extend(catalog.cat.get_all_sources())
+                crossmatch_catalog.extend(catalog.cat.get_sources_in_map(input_map))
 
             for_forced_photometry = []
             if self.forced_photometry_catalog:
                 for_forced_photometry.extend(
-                    self.forced_photometry_catalog.cat.get_all_sources()
+                    self.forced_photometry_catalog.cat.get_sources_in_map(input_map)
                 )
 
             for simulator in self.source_simulators:

--- a/sotrplib/sifter/crossmatch.py
+++ b/sotrplib/sifter/crossmatch.py
@@ -289,7 +289,7 @@ def sift(
     for source, cand_pos in enumerate(zip(extracted_ra, extracted_dec)):
         source_measurement = extracted_sources[source]
         source_string_name = radec_to_str_name(
-            cand_pos[0].to(u.rad).value, cand_pos[1].to(u.rad).value
+            cand_pos[0].to(u.deg).value, cand_pos[1].to(u.deg).value
         )
 
         if isin_cat[source]:

--- a/sotrplib/sims/sim_maps.py
+++ b/sotrplib/sims/sim_maps.py
@@ -13,6 +13,7 @@ from sotrplib.source_catalog.database import SourceCatalogDatabase
 from sotrplib.sources.forced_photometry import (
     convert_catalog_to_registered_source_objects,
 )
+from sotrplib.sources.sources import MeasuredSource
 
 
 def make_enmap(
@@ -305,7 +306,6 @@ def inject_sources(
     from pixell.enmap import sky2pix
     from tqdm import tqdm
 
-    from ..sources.sources import RegisteredSource
     from ..utils.utils import get_fwhm
     from .sim_utils import make_2d_gaussian_model_param_table
 
@@ -360,11 +360,15 @@ def inject_sources(
 
         flux = source.get_flux(source_obs_time)
 
-        inj_source = RegisteredSource(
+        inj_source = MeasuredSource(
             ra=ra,
             dec=dec,
             flux=flux,
             source_type="simulated",
+            fit_failed=False,
+            fwhm_ra=fwhm,
+            fwhm_dec=fwhm,
+            frequency=float(freq[1:]) * u.GHz if freq.startswith("f") else None,
         )
         injected_sources.append(inj_source)
     log.info("inject_sources.sources_to_inject", injected_sources=injected_sources)

--- a/sotrplib/sims/sim_utils.py
+++ b/sotrplib/sims/sim_utils.py
@@ -2,7 +2,6 @@ import numpy as np
 from astropy import units as u
 from astropydantic import AstroPydanticQuantity
 from pixell import enmap
-from pixell.utils import degree
 from structlog import get_logger
 from structlog.types import FilteringBoundLogger
 
@@ -191,7 +190,7 @@ def make_gaussian_flare(
 def convert_photutils_qtable_to_json(
     params,
     imap: enmap.ndmap = None,
-    log=None,
+    log: FilteringBoundLogger | None = None,
 ):
     """
     photutils params is an Astropy QTable with:
@@ -199,7 +198,8 @@ def convert_photutils_qtable_to_json(
 
     if imap supplied, will also get ra,dec
     """
-
+    log = log or get_logger()
+    log.bind(func_name="convert_photutils_qtable_to_json")
     json_cat_out = {}
     for p in params:
         for k in p.keys():
@@ -208,7 +208,7 @@ def convert_photutils_qtable_to_json(
             json_cat_out[k].append(p[k])
 
         if isinstance(imap, enmap.ndmap):
-            dec, ra = imap.pix2sky([p["y_0"], p["x_0"]]) / degree
+            dec, ra = np.degrees(imap.pix2sky([p["y_0"], p["x_0"]]))
         else:
             ra, dec = np.nan, np.nan
         if "RADeg" not in json_cat_out:

--- a/sotrplib/sims/sim_utils.py
+++ b/sotrplib/sims/sim_utils.py
@@ -454,6 +454,16 @@ def make_2d_gaussian_model_param_table(
         ## unfortunate naming, a,b are semi-major and semi-minor axes,
         ## but really they're x,y from photutils gaussian fit.
         cut = False
+        if s.fit_failed:
+            cut = True
+            if verbose:
+                log.debug(
+                    "make_2d_gaussian_model_param_table.cut_fit_failed",
+                    source_id=i,
+                    cutkey="fit_failed",
+                )
+            continue
+
         for cutkey in cuts.keys():
             if cutkey not in s.model_dump():
                 log.error(

--- a/sotrplib/source_catalog/database.py
+++ b/sotrplib/source_catalog/database.py
@@ -6,10 +6,10 @@ import structlog
 from astropy import units as u
 from astropy.io import fits
 from filelock import FileLock  # Import FileLock for file-based locking
-from pixell.enmap import ndmap
 from socat.client import mock
 from structlog.types import FilteringBoundLogger
 
+from sotrplib.maps.core import ProcessableMap
 from sotrplib.sources.sources import CrossMatch, MeasuredSource, RegisteredSource
 from sotrplib.utils.utils import angular_separation
 
@@ -18,7 +18,7 @@ class MockDatabase:
     def __init__(self, log: FilteringBoundLogger | None = None):
         self.cat = mock.Client()
         self.log = log or structlog.get_logger()
-        self.log.info("EmptyMockDatabase.initialized")
+        self.log.info("mock_database.initialized")
 
     def add_source(self, ra: u.Quantity, dec: u.Quantity, name: str):
         self.cat.create(ra=ra.to(u.deg).value, dec=dec.to(u.deg).value, name=name)
@@ -37,7 +37,7 @@ class MockDatabase:
             dec_max=dec + radius,
         )
         self.log.info(
-            "MockDatabase.get_nearby_source",
+            "mock_database.get_nearby_source",
             ra=ra,
             dec=dec,
             radius=radius,
@@ -64,7 +64,7 @@ class MockDatabase:
                 for s in nearby
             ]
         self.log.info(
-            "MockDatabase.get_nearby_source.nearby_sources",
+            "mock_database.get_nearby_source.nearby_sources",
             sources=sources,
         )
         return sources
@@ -100,8 +100,8 @@ class MockDatabase:
             )
         return sources
 
-    def get_sources_in_map(self, input_map: ndmap) -> list[RegisteredSource]:
-        map_bounds = input_map.box() * u.radian
+    def get_sources_in_map(self, input_map: ProcessableMap) -> list[RegisteredSource]:
+        map_bounds = input_map.flux.box() * u.radian
         return self.get_sources_in_box(box=map_bounds)
 
     def get_all_sources(self) -> list[RegisteredSource]:
@@ -117,13 +117,13 @@ class MockACTDatabase:
         db_path: str,
         log: FilteringBoundLogger | None = None,
         catalog_list: list = [],
-        flux_lower_limit: u.Quantity = 0.3 * u.Jy,
+        flux_lower_limit: u.Quantity = 0.01 * u.Jy,
     ):
         self.log = log or structlog.get_logger()
         hdu = fits.open(db_path)
         mock_cat = hdu[1]
         cat = MockDatabase()
-        self.log.info("MockACTDatabase.loading_act_catalog")
+        self.log.info("mock_act_database.loading_act_catalog")
         catalog_list = []
         for i in range(len(mock_cat.data["raDeg"])):  # This could be a zip I guess
             if mock_cat.data["fluxJy"][i] * u.Jy < flux_lower_limit:
@@ -132,29 +132,27 @@ class MockACTDatabase:
             if ra > 180:
                 ra -= 360  # Convention difference
             name = mock_cat.data["name"][i]
-            catalog_list.append(
-                RegisteredSource(
-                    ra=ra * u.deg,
-                    dec=dec * u.deg,
-                    source_id="%s"
-                    % str(i).zfill(len(str(len(mock_cat.data["raDeg"])))),
-                    crossmatches=[
-                        CrossMatch(
-                            source_id=name,
-                            probability=1.0,
-                            distance=0.0 * u.deg,
-                            frequency=90 * u.GHz,
-                            catalog_name="ACT",
-                            catalog_idx=i,
-                        )
-                    ],
-                )
+            registred_source = RegisteredSource(
+                ra=ra * u.deg,
+                dec=dec * u.deg,
+                source_id="%s" % str(i).zfill(len(str(len(mock_cat.data["raDeg"])))),
+                crossmatches=[
+                    CrossMatch(
+                        source_id=name,
+                        probability=1.0,
+                        distance=0.0 * u.deg,
+                        frequency=90 * u.GHz,
+                        catalog_name="ACT",
+                        catalog_idx=i,
+                    )
+                ],
             )
+            catalog_list.append(registred_source)
             cat.add_source(ra=ra * u.deg, dec=dec * u.deg, name=name)
         self.cat = cat
         self.log.info(
-            "MockACTDatabase.loaded_act_catalog",
-            n_sources=len(mock_cat.data["raDeg"]),
+            "mock_act_database.loaded_act_catalog",
+            n_sources=len(catalog_list),
         )
         self.catalog_list = catalog_list
 
@@ -170,63 +168,15 @@ class MockACTDatabase:
                 )
                 self.catalog_list.append(s)
                 self.log.info(
-                    "MockACTDatabase.update_catalog.new_source_added", source=s
+                    "mock_act_database.update_catalog.new_source_added", source=s
                 )
             else:
                 self.log.info(
-                    "MockACTDatabase.update_catalog.existing_source_found",
+                    "mock_act_database.update_catalog.existing_source_found",
                     source=source,
                     matching_sources=matches,
                 )
                 pass
-
-
-class MockForcedPhotometryDatabase:
-    def __init__(
-        self,
-        db_path: str,
-        log: FilteringBoundLogger | None = None,
-        flux_lower_limit: u.Quantity = 0.3 * u.Jy,
-        catalog_list: list = [],
-    ):
-        self.log = log or structlog.get_logger()
-        hdu = fits.open(db_path)
-        mock_cat = hdu[1]
-        cat = MockDatabase()
-        self.log.info("MockForcedPhotometryDatabase.loading_act_catalog")
-        catalog_list = []
-        for i in range(len(mock_cat.data["raDeg"])):  # This could be a zip I guess
-            ra, dec = mock_cat.data["raDeg"][i], mock_cat.data["decDeg"][i]
-            if ra > 180:
-                ra -= 360  # Convention difference
-            name = mock_cat.data["name"][i]
-            flux = mock_cat.data["fluxJy"][i] * u.Jy
-            if flux > flux_lower_limit:
-                catalog_list.append(
-                    RegisteredSource(
-                        ra=ra * u.deg,
-                        dec=dec * u.deg,
-                        source_id="%s"
-                        % str(i).zfill(len(str(len(mock_cat.data["raDeg"])))),
-                        crossmatches=[
-                            CrossMatch(
-                                source_id=name,
-                                probability=1.0,
-                                distance=0.0 * u.deg,
-                                frequency=90 * u.GHz,
-                                catalog_name="ACT",
-                                catalog_idx=i,
-                            )
-                        ],
-                    )
-                )
-                cat.add_source(ra=ra * u.deg, dec=dec * u.deg, name=name)
-        self.cat = cat
-        self.log.info(
-            "MockForcedPhotometryDatabase.loaded_act_catalog",
-            n_sources=len(mock_cat.data["raDeg"]),
-        )
-        self.catalog_list = catalog_list
 
 
 class SourceCatalogDatabase:

--- a/sotrplib/sources/blind.py
+++ b/sotrplib/sources/blind.py
@@ -23,7 +23,7 @@ class BlindSearchParameters(BaseModel):
     Parameters for blind source searching using photutils.
     """
 
-    sigma_threshold: float = 5.0
+    sigma_threshold: float = 20.0
     minimum_separation: list[AstroPydanticQuantity[u.arcmin]] = [
         AstroPydanticQuantity(u.Quantity(0.5, "arcmin"))
     ]

--- a/sotrplib/sources/forced_photometry.py
+++ b/sotrplib/sources/forced_photometry.py
@@ -250,9 +250,11 @@ def scipy_2d_gaussian_fit(
             ra=source.ra, dec=source.dec, source_id=source.source_id, flux=source.flux
         )
         forced_source.fit_method = fit_method
+        ## set default fit to empty parameters and fit_failed.
+        ## once the fit is successfully completed, this will be updated.
         fit = GaussianFitParameters()
         fit.failed = True
-
+        forced_source.fit_failed = True
         if (
             pix[0] + size_pix > input_map.flux.shape[0]
             or pix[1] + size_pix > input_map.flux.shape[1]
@@ -260,6 +262,7 @@ def scipy_2d_gaussian_fit(
             or pix[1] - size_pix < 0
         ):
             fit.failure_reason = "source_outside_map_bounds"
+            forced_source.fit_failure_reason = "source_outside_map_bounds"
             log.warning(
                 f"{preamble}source_outside_map_bounds",
                 source=source_name,
@@ -279,14 +282,12 @@ def scipy_2d_gaussian_fit(
             log.error(
                 f"{preamble}extract_thumbnail_failed", source=source_name, error=e
             )
-            forced_source.fit_failed = True
             forced_source.fit_failure_reason = "extract_thumbnail_failed"
             fit_sources.append(forced_source)
             continue
 
         if np.any(np.isnan(forced_source.thumbnail)):
             log.warning(f"{preamble}flux_thumb_has_nan", source=source_name)
-            forced_source.fit_failed = True
             forced_source.fit_failure_reason = "flux_thumb_has_nan"
             fit_sources.append(forced_source)
             continue

--- a/sotrplib/sources/forced_photometry.py
+++ b/sotrplib/sources/forced_photometry.py
@@ -159,7 +159,7 @@ class Gaussian2DFitter:
             self.log.error("curve_fit_2d_gaussian.curve_fit.failed")
             self.fit_params.failed = True
             self.fit_params.failure_reason = "curve_fit_runtime_error"
-            return
+            return self.fit_params
 
         self.log.debug("curve_fit_2d_gaussian.curve_fit.success", popt=popt)
         perr = np.sqrt(np.diag(pcov))  # Parameter uncertainties
@@ -279,12 +279,14 @@ def scipy_2d_gaussian_fit(
             log.error(
                 f"{preamble}extract_thumbnail_failed", source=source_name, error=e
             )
+            forced_source.fit_failed = True
             forced_source.fit_failure_reason = "extract_thumbnail_failed"
             fit_sources.append(forced_source)
             continue
 
         if np.any(np.isnan(forced_source.thumbnail)):
             log.warning(f"{preamble}flux_thumb_has_nan", source=source_name)
+            forced_source.fit_failed = True
             forced_source.fit_failure_reason = "flux_thumb_has_nan"
             fit_sources.append(forced_source)
             continue

--- a/sotrplib/utils/utils.py
+++ b/sotrplib/utils/utils.py
@@ -20,14 +20,14 @@ def radec_to_str_name(
     ra: float, dec: float, source_class="pointsource", observatory="SO"
 ):
     """
-    Convert RA & dec (in radians) to IAU-approved string name.
+    Convert RA & dec (in degrees) to IAU-approved string name.
 
     Arguments
     ---------
     ra : float
-        Source right ascension in radians
+        Source right ascension in degrees
     dec : float
-        Source declination in radians
+        Source declination in degrees
     source_class : str
         The class of source to which this name is assigned.  Supported classes
         are ``pointsource``, ``cluster`` or ``transient``.  Shorthand class

--- a/tests/test_data_pipeline/test_data_pipeline.py
+++ b/tests/test_data_pipeline/test_data_pipeline.py
@@ -16,7 +16,6 @@ from sotrplib.outputs.core import PickleSerializer
 from sotrplib.sifter.core import DefaultSifter
 from sotrplib.source_catalog.database import (
     MockACTDatabase,
-    MockForcedPhotometryDatabase,
 )
 from sotrplib.sources.blind import BlindSearchParameters, SigmaClipBlindSearch
 from sotrplib.sources.force import SimpleForcedPhotometry
@@ -32,7 +31,7 @@ def test_mock_forced_photometry_database(
     Tests loading a mock forced photometry database.
     """
     log = log or structlog.get_logger()
-    catalog = MockForcedPhotometryDatabase(db_path=db_path)
+    catalog = MockACTDatabase(db_path=db_path, flux_lower_limit=1 * u.Jy)
     assert len(catalog.catalog_list) > 0
     log.info(
         "mock_forced_photometry_catalog.catalog_list",
@@ -65,7 +64,7 @@ def test_basic_map_pipeline(
         frequency="f090",
         array="pa5",
     )
-    forced_photometry_sources = MockForcedPhotometryDatabase(
+    forced_photometry_sources = MockACTDatabase(
         db_path="/scratch/gpfs/SIMONSOBS/users/amfoster/depth1_act_maps/inputs/PS_S19_f090_2pass_optimalCatalog.fits",
         flux_lower_limit=1 * u.Jy,
     ).catalog_list

--- a/tests/test_forced_photometry/test_forced_photometry.py
+++ b/tests/test_forced_photometry/test_forced_photometry.py
@@ -46,10 +46,6 @@ def test_scipy_curve_fit(map_with_single_source):
     assert len(results) == 1
     ntries = 10
     if results[0].fit_failed:
-        assert (
-            results[0].fit_failure_reason
-            == "source_outside_map_bounds" | "flux_thumb_has_nan"
-        )
         while results[0].fit_failed and ntries > 0:
             results = forced_photometry.force(
                 input_map=input_map,
@@ -70,4 +66,3 @@ def test_failed_fit(map_with_single_source):
     results = forced_photometry.force(input_map=input_map, sources=sources)
     assert len(results) == 1
     assert results[0].fit_failed
-    assert results[0].fit_failure_reason == "flux_thumb_has_nan"

--- a/tests/test_forced_photometry/test_forced_photometry.py
+++ b/tests/test_forced_photometry/test_forced_photometry.py
@@ -46,7 +46,10 @@ def test_scipy_curve_fit(map_with_single_source):
     assert len(results) == 1
     ntries = 10
     if results[0].fit_failed:
-        assert results[0].fit_failure_reason == "source_near_map_edge"
+        assert (
+            results[0].fit_failure_reason
+            == "source_outside_map_bounds" | "flux_thumb_has_nan"
+        )
         while results[0].fit_failed and ntries > 0:
             results = forced_photometry.force(
                 input_map=input_map,
@@ -65,7 +68,6 @@ def test_failed_fit(map_with_single_source):
     input_map.flux *= np.nan
     forced_photometry = Scipy2DGaussianFitter(reproject_thumbnails=True)
     results = forced_photometry.force(input_map=input_map, sources=sources)
-    print(results)
     assert len(results) == 1
     assert results[0].fit_failed
     assert results[0].fit_failure_reason == "flux_thumb_has_nan"

--- a/tests/test_forced_photometry/test_forced_photometry.py
+++ b/tests/test_forced_photometry/test_forced_photometry.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 from astropy import units as u
 
@@ -57,3 +58,14 @@ def test_scipy_curve_fit(map_with_single_source):
         sources[0].flux.to(u.Jy).value, rel=2e-1
     )
     assert results[0].fit_method == "2d_gaussian"
+
+
+def test_failed_fit(map_with_single_source):
+    input_map, sources = map_with_single_source
+    input_map.flux *= np.nan
+    forced_photometry = Scipy2DGaussianFitter(reproject_thumbnails=True)
+    results = forced_photometry.force(input_map=input_map, sources=sources)
+    print(results)
+    assert len(results) == 1
+    assert results[0].fit_failed
+    assert results[0].fit_failure_reason == "flux_thumb_has_nan"

--- a/tests/test_maps/test_io.py
+++ b/tests/test_maps/test_io.py
@@ -18,6 +18,8 @@ def test_basic_pipeline_rhokappa(tmp_path, ones_map_set):
     ).to_map()
     runner = PipelineRunner(
         maps=[input_map],
+        forced_photometry_catalog=None,
+        source_catalogs=[],
         preprocessors=None,
         postprocessors=None,
         source_simulators=None,
@@ -43,6 +45,8 @@ def test_basic_pipeline_ivar(tmp_path, ones_map_set):
     ).to_map()
     runner = PipelineRunner(
         maps=[input_map],
+        forced_photometry_catalog=None,
+        source_catalogs=[],
         preprocessors=None,
         postprocessors=None,
         source_simulators=None,

--- a/tests/test_simulation_pipeline/test_pipeline.py
+++ b/tests/test_simulation_pipeline/test_pipeline.py
@@ -46,6 +46,8 @@ def test_basic_pipeline_scipy(
 
     runner = PipelineRunner(
         maps=[new_map, new_map],
+        forced_photometry_catalog=None,
+        source_catalogs=[],
         preprocessors=None,
         postprocessors=None,
         source_simulators=None,


### PR DESCRIPTION
Use mock socat to load the act database. 

Functionality includes a flux limit so that one can produce a fake forced photometry catalog.

Fixed get_sources_in_map where box wraps around 0.

Fixed returned ra,dec offsets from forced photometry.

Fixed string name (source_id) in crossmatch call to radec_to_str_name