### PR TITLE
Add thumbnail extraction in blind search

### DIFF
--- a/sotrplib/sources/blind.py
+++ b/sotrplib/sources/blind.py
@@ -67,4 +67,8 @@ class SigmaClipBlindSearch(BlindSearchProvider):
             sigma_thresh_for_minrad=self.parameters.sigma_threshold_for_minimum_separation,
             log=self.log,
         )
+
+        for source in extracted_sources:
+            source.extract_thumbnail(input_map=input_map)
+
         return extracted_sources, []


### PR DESCRIPTION
Makes sources extracted via blind search also compute their own thumbnails.