### PR TITLE
Fix CI test coverage

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -25,8 +25,8 @@ jobs:
         uses: astral-sh/setup-uv@v6
 
       - name: Sync uv
-        run: uv pip install pixell; uv pip install ".[dev,prefect]"
+        run: uv pip install pixell; uv pip install -e ".[dev,prefect]"
 
       - name: Run tests
-        run: pytest --cov=sotrplib
+        run: pytest --cov
         


### PR DESCRIPTION
There should be a way to make this work without requiring an editable install, but it works now. I suspect it's a uv thing.

Do we want to hook up to codecov to get nice reports/badges?