### PR TITLE
make sure all datetimes have a timezone

### DIFF
--- a/sample_sim_map.json
+++ b/sample_sim_map.json
@@ -2,8 +2,8 @@
     "maps": [
         {
             "map_type": "simulated",
-            "observation_start": "2025-01-01",
-            "observation_end": "2025-01-02"
+            "observation_start": "2025-01-01:T00:00:00Z",
+            "observation_end": "2025-01-02:T00:00:00Z"
         }
     ],
     "source_simulators": [

--- a/sotrplib/config/maps.py
+++ b/sotrplib/config/maps.py
@@ -3,13 +3,12 @@ Map configuration
 """
 
 from abc import ABC, abstractmethod
-from datetime import datetime
 from pathlib import Path
 from typing import Iterable, Literal
 
 from astropy import units as u
 from astropydantic import AstroPydanticQuantity, AstroPydanticUnit
-from pydantic import BaseModel, Field, model_validator
+from pydantic import AwareDatetime, BaseModel, Field, model_validator
 from structlog.types import FilteringBoundLogger
 
 from sotrplib.maps.core import (
@@ -45,8 +44,8 @@ class MapGeneratorConfig(BaseModel, ABC):
 
 class SimulatedMapConfig(MapConfig):
     map_type: Literal["simulated"] = "simulated"
-    observation_start: datetime
-    observation_end: datetime
+    observation_start: AwareDatetime
+    observation_end: AwareDatetime
     frequency: str = "f090"
     array: str = "pa5"
     simulation_parameters: SimulationParameters = Field(
@@ -68,8 +67,8 @@ class SimulatedMapFromGeometryConfig(MapConfig):
     map_type: Literal["simulated_geometry"] = "simulated_geometry"
     resolution: AstroPydanticQuantity[u.arcmin]
     geometry_source_map: Path
-    observation_start: datetime | None
-    observation_end: datetime | None
+    observation_start: AwareDatetime | None
+    observation_end: AwareDatetime | None
     time_map_filename: Path | None
     frequency: str = "f090"
     array: str = "pa5"
@@ -111,8 +110,8 @@ class RhoKappaMapConfig(MapConfig):
     frequency: str | None = "f090"
     array: str | None = "pa5"
     instrument: str | None = None
-    observation_start: datetime | None = None
-    observation_end: datetime | None = None
+    observation_start: AwareDatetime | None = None
+    observation_end: AwareDatetime | None = None
     box: AstroPydanticQuantity[u.deg] | None = None
     flux_units: AstroPydanticUnit = u.Unit("Jy")
 
@@ -142,8 +141,8 @@ class InverseVarianceMapConfig(MapConfig):
     frequency: str | None = "f090"
     array: str | None = "pa5"
     instrument: str | None = None
-    observation_start: datetime | None = None
-    observation_end: datetime | None = None
+    observation_start: AwareDatetime | None = None
+    observation_end: AwareDatetime | None = None
     box: AstroPydanticQuantity[u.deg] | None = None
     intensity_units: AstroPydanticUnit = u.Unit("K")
 

--- a/sotrplib/config/source_simulation.py
+++ b/sotrplib/config/source_simulation.py
@@ -1,10 +1,10 @@
 from abc import ABC, abstractmethod
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Literal
 
 from astropy import units as u
 from astropydantic import AstroPydanticQuantity
-from pydantic import BaseModel
+from pydantic import AwareDatetime, BaseModel
 from structlog.types import FilteringBoundLogger
 
 from sotrplib.sims.sim_source_generators import (
@@ -51,8 +51,8 @@ class GaussianTransientSourceGeneratorConfig(SourceSimulationConfig):
     peak_amplitude_minimum: AstroPydanticQuantity[u.Jy]
     peak_amplitude_maximum: AstroPydanticQuantity[u.Jy]
     number: int
-    flare_earliest_time: datetime | None = None
-    flare_latest_time: datetime | None = None
+    flare_earliest_time: AwareDatetime | None = None
+    flare_latest_time: AwareDatetime | None = None
     catalog_fraction: float = 1.0
 
     def to_simulator(

--- a/sotrplib/maps/core.py
+++ b/sotrplib/maps/core.py
@@ -14,6 +14,7 @@ from astropy.units import Unit
 from astropydantic import AstroPydanticQuantity
 from pixell import enmap
 from pixell.enmap import ndmap
+from pydantic import AwareDatetime
 from structlog.types import FilteringBoundLogger
 
 
@@ -64,11 +65,11 @@ class ProcessableMap(ABC):
 
     observation_length: timedelta
     "Total length of the observation"
-    observation_start: datetime
+    observation_start: AwareDatetime
     "Start time of the observation"
-    observation_end: datetime
+    observation_end: AwareDatetime
     "End time of the observation"
-    observation_time: datetime
+    observation_time: AwareDatetime
     "Rough 'middle' time of the observation"
 
     flux_units: Unit
@@ -270,8 +271,8 @@ class IntensityAndInverseVarianceMap(ProcessableMap):
         self,
         intensity_filename: Path,
         inverse_variance_filename: Path,
-        start_time: datetime,
-        end_time: datetime,
+        start_time: AwareDatetime,
+        end_time: AwareDatetime,
         box: AstroPydanticQuantity[u.deg] | None = None,
         time_filename: Path | None = None,
         info_filename: Path | None = None,
@@ -529,8 +530,8 @@ class RhoAndKappaMap(ProcessableMap):
         self,
         rho_filename: Path,
         kappa_filename: Path,
-        start_time: datetime,
-        end_time: datetime,
+        start_time: AwareDatetime,
+        end_time: AwareDatetime,
         box: AstroPydanticQuantity[u.deg] | None = None,
         time_filename: Path | None = None,
         info_filename: Path | None = None,
@@ -679,8 +680,8 @@ class CoaddedMap(ProcessableMap):
         time_mean: ndmap | None = None,
         time_end: ndmap | None = None,
         map_depth: ndmap | None = None,
-        start_time: datetime | None = None,
-        end_time: datetime | None = None,
+        start_time: AwareDatetime | None = None,
+        end_time: AwareDatetime | None = None,
         input_map_times: list[float] | None = None,
         frequency: str | None = None,
         array: str | None = None,

--- a/sotrplib/sims/maps.py
+++ b/sotrplib/sims/maps.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from pathlib import Path
 
 import astropy.units as u
@@ -8,7 +7,7 @@ from astropy.units import Quantity
 from astropydantic import AstroPydanticQuantity
 from numpy.typing import ArrayLike
 from pixell import enmap
-from pydantic import BaseModel
+from pydantic import AwareDatetime, BaseModel
 from structlog.types import FilteringBoundLogger
 
 from sotrplib.maps.core import ProcessableMap
@@ -32,8 +31,8 @@ class SimulationParameters(BaseModel):
 class SimulatedMap(ProcessableMap):
     def __init__(
         self,
-        observation_start: datetime,
-        observation_end: datetime,
+        observation_start: AwareDatetime,
+        observation_end: AwareDatetime,
         frequency: str | None = None,
         array: str | None = None,
         instrument: str | None = None,
@@ -141,8 +140,8 @@ class SimulatedMapFromGeometry(ProcessableMap):
         self,
         resolution: Quantity,
         geometry_source_map: Path,
-        start_time: datetime | None,
-        end_time: datetime | None,
+        start_time: AwareDatetime | None,
+        end_time: AwareDatetime | None,
         time_map_filename: Path | None = None,
         frequency: str | None = None,
         array: str | None = None,

--- a/sotrplib/sims/sim_source_generators.py
+++ b/sotrplib/sims/sim_source_generators.py
@@ -6,10 +6,11 @@ the random generation of those sources.
 
 import random
 from abc import ABC
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from astropy import units as u
 from astropy.coordinates import SkyCoord
+from pydantic import AwareDatetime
 from structlog import get_logger
 from structlog.types import FilteringBoundLogger
 
@@ -37,7 +38,7 @@ class SimulatedSourceGenerator(ABC):
         self,
         input_map: ProcessableMap | None = None,
         box: tuple[SkyCoord] | None = None,
-        time_range: tuple[datetime | None, datetime | None] | None = None,
+        time_range: tuple[AwareDatetime | None, AwareDatetime | None] | None = None,
     ) -> tuple[list[SimulatedSource], SourceCatalog]:
         """
         Generate the simulated sources, optionally within a map or a box on the sky.
@@ -73,7 +74,7 @@ class FixedSourceGenerator(SimulatedSourceGenerator):
         self,
         input_map: ProcessableMap | None = None,
         box: tuple[SkyCoord] | None = None,
-        time_range: tuple[datetime | None, datetime | None] | None = None,
+        time_range: tuple[AwareDatetime | None, AwareDatetime | None] | None = None,
     ):
         if box is None and input_map is None:
             box = [
@@ -136,8 +137,8 @@ class FixedSourceGenerator(SimulatedSourceGenerator):
 class GaussianTransientSourceGenerator(SimulatedSourceGenerator):
     def __init__(
         self,
-        flare_earliest_time: datetime | None,
-        flare_latest_time: datetime | None,
+        flare_earliest_time: AwareDatetime | None,
+        flare_latest_time: AwareDatetime | None,
         flare_width_shortest: timedelta,
         flare_width_longest: timedelta,
         peak_amplitude_minimum: u.Quantity,
@@ -160,7 +161,7 @@ class GaussianTransientSourceGenerator(SimulatedSourceGenerator):
         self,
         input_map: ProcessableMap | None = None,
         box: tuple[SkyCoord] | None = None,
-        time_range: tuple[datetime | None, datetime | None] | None = None,
+        time_range: tuple[AwareDatetime | None, AwareDatetime | None] | None = None,
     ):
         if box is None and input_map is None:
             box = [

--- a/sotrplib/sims/sim_sources.py
+++ b/sotrplib/sims/sim_sources.py
@@ -1,20 +1,21 @@
 import math
 from abc import ABC, abstractmethod
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropydantic import AstroPydanticQuantity
 from pixell import enmap
+from pydantic import AwareDatetime
 
 
 class SimulatedSource(ABC):
     @abstractmethod
-    def position(self, time: datetime) -> SkyCoord:
+    def position(self, time: AwareDatetime) -> SkyCoord:
         return
 
     @abstractmethod
-    def flux(self, time: datetime) -> u.Quantity:
+    def flux(self, time: AwareDatetime) -> u.Quantity:
         return
 
 
@@ -40,7 +41,7 @@ class GaussianTransientSimulatedSource(SimulatedSource):
     def __init__(
         self,
         position: SkyCoord,
-        peak_time: datetime,
+        peak_time: AwareDatetime,
         flare_width: timedelta,
         peak_amplitude: u.Quantity = 0.0 * u.Jy,
     ):
@@ -62,10 +63,10 @@ class GaussianTransientSimulatedSource(SimulatedSource):
 
         return
 
-    def position(self, time: datetime) -> SkyCoord:
+    def position(self, time: AwareDatetime) -> SkyCoord:
         return self._position
 
-    def flux(self, time: datetime) -> u.Quantity:
+    def flux(self, time: AwareDatetime) -> u.Quantity:
         delta_time = time - self.peak_time
 
         sigma = self.flare_width / (2.0 * math.sqrt(2.0 * math.log(2.0)))

--- a/sotrplib/source_catalog/core.py
+++ b/sotrplib/source_catalog/core.py
@@ -172,7 +172,9 @@ class RegisteredSourceCatalog(SourceCatalog):
             CrossMatch(
                 source_id=str(s.source_id),
                 probability=1.0 / len(sources),
-                angular_separation=angular_separation(ra1=s.ra, dec1=s.dec, ra2=ra, dec2=dec),
+                angular_separation=angular_separation(
+                    ra1=s.ra, dec1=s.dec, ra2=ra, dec2=dec
+                ),
                 flux=s.flux,
                 err_flux=s.err_flux,
                 frequency=s.frequency,

--- a/tests/regression/regression.json
+++ b/tests/regression/regression.json
@@ -2,8 +2,8 @@
     "maps": [
         {
             "map_type": "simulated",
-            "observation_start": "2025-01-01",
-            "observation_end": "2025-01-02",
+            "observation_start": "2025-01-01T00:00:00Z",
+            "observation_end": "2025-01-02T00:00:00Z",
             "simulation_parameters": {
                 "center_ra": "90.0 deg",
                 "center_dec": "0.0 deg",

--- a/tests/test_forced_photometry/conftest.py
+++ b/tests/test_forced_photometry/conftest.py
@@ -17,8 +17,9 @@ from sotrplib.sims.sources.core import (
 @pytest.fixture
 def empty_map():
     map = SimulatedMap(
-        observation_start=datetime.datetime.now() - datetime.timedelta(days=1),
-        observation_end=datetime.datetime.now(),
+        observation_start=datetime.datetime.now(tz=datetime.UTC)
+        - datetime.timedelta(days=1),
+        observation_end=datetime.datetime.now(tz=datetime.UTC),
     )
 
     map.build()

--- a/tests/test_pointing/conftest.py
+++ b/tests/test_pointing/conftest.py
@@ -27,8 +27,9 @@ map_sim_params = SimulationParameters(
 def empty_map():
     map = SimulatedMap(
         simulation_parameters=map_sim_params,
-        observation_start=datetime.datetime.now(),
-        observation_end=datetime.datetime.now() + datetime.timedelta(hours=8),
+        observation_start=datetime.datetime.now(tz=datetime.UTC),
+        observation_end=datetime.datetime.now(tz=datetime.UTC)
+        + datetime.timedelta(hours=8),
     )
 
     map.build()

--- a/tests/test_prefect_pipeline/test_prefect_pipeline.py
+++ b/tests/test_prefect_pipeline/test_prefect_pipeline.py
@@ -14,31 +14,6 @@ from sotrplib.sources.blind import SigmaClipBlindSearch
 from sotrplib.sources.force import Scipy2DGaussianFitter
 from sotrplib.sources.sources import MeasuredSource, RegisteredSource
 
-sample_setup = {
-    "maps": [
-        {
-            "map_type": "simulated",
-            "observation_start": "2025-01-01",
-            "observation_end": "2025-01-02",
-        }
-    ],
-    "source_simulators": [
-        {
-            "simulation_type": "fixed",
-            "number": 8,
-            "min_flux": "3.0 Jy",
-            "max_flux": "10.0 Jy",
-            "catalog_fraction": 0.5,
-        }
-    ],
-    "source_injector": {"injector_type": "photutils"},
-    "forced_photometry": {"photometry_type": "scipy"},
-    "source_subtractor": {"subtractor_type": "photutils"},
-    "blind_search": {"search_type": "photutils"},
-    "sifter": {"sifter_type": "simple"},
-    "outputs": [{"output_type": "pickle", "directory": "."}],
-}
-
 
 def test_basic_pipeline_scipy(
     tmp_path, map_with_sources: tuple[SimulatedMap, list[RegisteredSource]]

--- a/tests/test_sims/conftest.py
+++ b/tests/test_sims/conftest.py
@@ -131,8 +131,9 @@ def dummy_map(sim_map_params, ones_map_set):
         rho_filename=ones_map_set["rho"],
         kappa_filename=ones_map_set["kappa"],
         time_filename=ones_map_set["time"],
-        start_time=datetime.datetime.now() - 1 * datetime.timedelta(days=1),
-        end_time=datetime.datetime.now(),
+        start_time=datetime.datetime.now(tz=datetime.UTC)
+        - 1 * datetime.timedelta(days=1),
+        end_time=datetime.datetime.now(tz=datetime.UTC),
     )
     DummyMap.build()
     DummyMap.add_time_offset(DummyMap.observation_start)

--- a/tests/test_sims/test_sim_source_injection.py
+++ b/tests/test_sims/test_sim_source_injection.py
@@ -17,7 +17,7 @@ log = get_logger()
 def test_fixed_source_type():
     position = SkyCoord(ra=90.0 * u.deg, dec=0.0 * u.deg)
     flux = u.Quantity(1.0, "Jy")
-    time = datetime.datetime.now()
+    time = datetime.datetime.now(tz=datetime.UTC)
 
     source = sim_sources.FixedSimulatedSource(position=position, flux=flux)
     assert source.flux(time=time) == flux
@@ -28,7 +28,7 @@ def test_gaussian_source_type():
     position = SkyCoord(ra=90.0 * u.deg, dec=0.0 * u.deg)
     flux = u.Quantity(1.0, "Jy")
     width = datetime.timedelta(days=1)
-    time = datetime.datetime.now()
+    time = datetime.datetime.now(tz=datetime.UTC)
 
     source = sim_sources.GaussianTransientSimulatedSource(
         position=position, peak_time=time, flare_width=width, peak_amplitude=flux
@@ -51,7 +51,7 @@ def test_fixed_source_generation():
     right = 20.0 * u.deg
     bottom = 0.0 * u.deg
     top = 10.0 * u.deg
-    time = datetime.datetime.now()
+    time = datetime.datetime.now(tz=datetime.UTC)
     number = 32
 
     generator = sim_source_generators.FixedSourceGenerator(
@@ -81,7 +81,7 @@ def test_gaussian_source_generation():
     right = 20.0 * u.deg
     bottom = 0.0 * u.deg
     top = 10.0 * u.deg
-    time = datetime.datetime.now()
+    time = datetime.datetime.now(tz=datetime.UTC)
     dt = datetime.timedelta(hours=2)
     earliest = time - dt
     latest = time + dt
@@ -126,8 +126,9 @@ def test_source_injection_into_map():
         catalog_fraction=0.5,
     )
 
-    start_obs = datetime.datetime.now() - datetime.timedelta(hours=2)
-    end_obs = datetime.datetime.now()
+    start_obs = datetime.datetime.now(tz=datetime.UTC)
+    -datetime.timedelta(hours=2)
+    end_obs = datetime.datetime.now(tz=datetime.UTC)
 
     base_map = maps.SimulatedMap(
         observation_start=start_obs,


### PR DESCRIPTION
Closes #104 

The main change for users is that simulated map config files now need an explicit time including timezone.