### PR TITLE
Remove scipy 2D gaussian fitting, require lmfit version (#154)

### DIFF
--- a/scripts/depth1_map_analysis/slurm_wrapper_depth1_map_analysis.py
+++ b/scripts/depth1_map_analysis/slurm_wrapper_depth1_map_analysis.py
@@ -218,7 +218,7 @@ def generate_config_json(
         }}
     ],
     "pointing_provider": {{
-        "photometry_type": "scipy_pointing",
+        "photometry_type": "lmfit_pointing",
         "thumbnail_half_width": "{thumbnail_half_width}",
         "min_flux": "{pointing_flux_threshold}",
         "reproject_thumbnails": "True",

--- a/scripts/depth1_map_analysis/slurm_wrapper_websky_depth1_map_analysis.py
+++ b/scripts/depth1_map_analysis/slurm_wrapper_websky_depth1_map_analysis.py
@@ -207,7 +207,7 @@ def generate_config_json(
         }}
     ],
     "pointing_provider": {{
-        "photometry_type": "scipy_pointing",
+        "photometry_type": "lmfit_pointing",
         "thumbnail_half_width": "{thumbnail_half_width}",
         "min_flux": "{pointing_flux_threshold}",
         "reproject_thumbnails": "True"

--- a/sotrplib/config/forced_photometry.py
+++ b/sotrplib/config/forced_photometry.py
@@ -42,30 +42,6 @@ class SimpleForcedPhotometryConfig(ForcedPhotometryConfig):
         return SimpleForcedPhotometry(mode=self.mode, log=log)
 
 
-class ScipyGaussianFitterConfig(ForcedPhotometryConfig):
-    photometry_type: Literal["scipy"] = "scipy"
-    flux_limit_centroid: AstroPydanticQuantity[u.Jy] = u.Quantity(0.3, "Jy")
-    reproject_thumbnails: bool = False
-    thumbnail_half_width: AstroPydanticQuantity[u.deg] = u.Quantity(0.1, "deg")
-    allowable_center_offset: AstroPydanticQuantity[u.arcmin] = u.Quantity(1.0, "arcmin")
-    near_source_rel_flux_limit: float = 1.0
-    goodness_of_fit_threshold: float | None = None
-
-    def to_forced_photometry(
-        self, log: FilteringBoundLogger | None = None
-    ) -> TwoDGaussianFitter:
-        return TwoDGaussianFitter(
-            mode="scipy",
-            flux_limit_centroid=self.flux_limit_centroid,
-            reproject_thumbnails=self.reproject_thumbnails,
-            thumbnail_half_width=self.thumbnail_half_width,
-            allowable_center_offset=self.allowable_center_offset,
-            near_source_rel_flux_limit=self.near_source_rel_flux_limit,
-            goodness_of_fit_threshold=self.goodness_of_fit_threshold,
-            log=log,
-        )
-
-
 class LmfitGaussianFitterConfig(ForcedPhotometryConfig):
     photometry_type: Literal["lmfit"] = "lmfit"
     flux_limit_centroid: AstroPydanticQuantity[u.Jy] = u.Quantity(0.3, "Jy")
@@ -81,30 +57,6 @@ class LmfitGaussianFitterConfig(ForcedPhotometryConfig):
         return TwoDGaussianFitter(
             mode="lmfit",
             flux_limit_centroid=self.flux_limit_centroid,
-            reproject_thumbnails=self.reproject_thumbnails,
-            thumbnail_half_width=self.thumbnail_half_width,
-            allowable_center_offset=self.allowable_center_offset,
-            near_source_rel_flux_limit=self.near_source_rel_flux_limit,
-            goodness_of_fit_threshold=self.goodness_of_fit_threshold,
-            log=log,
-        )
-
-
-class Scipy2DGaussianPointingConfig(ForcedPhotometryConfig):
-    photometry_type: Literal["scipy_pointing"] = "scipy_pointing"
-    min_flux: AstroPydanticQuantity[u.Jy] = u.Quantity(0.3, "Jy")
-    reproject_thumbnails: bool = False
-    thumbnail_half_width: AstroPydanticQuantity[u.deg] = u.Quantity(0.1, "deg")
-    allowable_center_offset: AstroPydanticQuantity[u.arcmin] = u.Quantity(3.0, "arcmin")
-    near_source_rel_flux_limit: float = 0.3
-    goodness_of_fit_threshold: float | None = None
-
-    def to_forced_photometry(
-        self, log: FilteringBoundLogger | None = None
-    ) -> TwoDGaussianPointingFitter:
-        return TwoDGaussianPointingFitter(
-            mode="scipy",
-            min_flux=self.min_flux,
             reproject_thumbnails=self.reproject_thumbnails,
             thumbnail_half_width=self.thumbnail_half_width,
             allowable_center_offset=self.allowable_center_offset,
@@ -140,9 +92,7 @@ class Lmfit2DGaussianPointingConfig(ForcedPhotometryConfig):
 
 AllForcedPhotometryConfigTypes = (
     EmptyPhotometryConfig
-    | ScipyGaussianFitterConfig
     | SimpleForcedPhotometryConfig
-    | Scipy2DGaussianPointingConfig
     | LmfitGaussianFitterConfig
     | Lmfit2DGaussianPointingConfig
 )

--- a/sotrplib/sources/force.py
+++ b/sotrplib/sources/force.py
@@ -93,7 +93,7 @@ class SimpleForcedPhotometry(ForcedPhotometryProvider):
 
 
 class TwoDGaussianFitter(ForcedPhotometryProvider):
-    mode: Literal["scipy", "lmfit"] = "lmfit"
+    mode: Literal["lmfit"] = "lmfit"
     flux_limit_centroid: u.Quantity  ## this should probably not exist within the function; i.e. be decided before handing the list to the provider.
     reproject_thumbnails: bool
     allowable_center_offset: u.Quantity
@@ -104,7 +104,7 @@ class TwoDGaussianFitter(ForcedPhotometryProvider):
 
     def __init__(
         self,
-        mode: Literal["scipy", "lmfit"] = "lmfit",
+        mode: Literal["lmfit"] = "lmfit",
         flux_limit_centroid: u.Quantity = u.Quantity(0.3, "Jy"),
         reproject_thumbnails: bool = False,
         thumbnail_half_width: u.Quantity = u.Quantity(0.1, "deg"),
@@ -117,9 +117,8 @@ class TwoDGaussianFitter(ForcedPhotometryProvider):
         Initialize the GaussianFitter.
         Parameters
         ----------
-        mode : {"scipy", "lmfit"}, optional
-            The method to use for fitting the Gaussian. Options are "scipy" for
-            scipy.optimize.curve_fit or "lmfit" for the lmfit library. The default is "lmfit".
+        mode : {"lmfit"}, optional
+            The method to use for fitting the Gaussian. Currently only "lmfit" is supported.
         flux_limit_centroid : astropy.units.Quantity, optional
             Minimum flux required to attempt centroid fitting (default: 0.3 Jy).
         reproject_thumbnails : bool, optional
@@ -231,7 +230,7 @@ class TwoDGaussianFitter(ForcedPhotometryProvider):
 
 
 class TwoDGaussianPointingFitter(ForcedPhotometryProvider):
-    mode: Literal["scipy", "lmfit"] = "lmfit"
+    mode: Literal["lmfit"] = "lmfit"
     min_flux: u.Quantity
     reproject_thumbnails: bool
     thumbnail_half_width: u.Quantity
@@ -242,7 +241,7 @@ class TwoDGaussianPointingFitter(ForcedPhotometryProvider):
 
     def __init__(
         self,
-        mode: Literal["scipy", "lmfit"] = "lmfit",
+        mode: Literal["lmfit"] = "lmfit",
         min_flux: u.Quantity = u.Quantity(0.3, "Jy"),
         reproject_thumbnails: bool = False,
         thumbnail_half_width: u.Quantity = u.Quantity(0.1, "deg"),
@@ -252,12 +251,11 @@ class TwoDGaussianPointingFitter(ForcedPhotometryProvider):
         log: FilteringBoundLogger | None = None,
     ):
         """
-        Initialize the Scipy2DGaussianFitter.
+        Initialize the TwoDGaussianPointingFitter.
         Parameters
         ----------
-        mode : {"scipy", "lmfit"}, optional
-            The method to use for fitting the Gaussian. Options are "scipy" for
-            scipy.optimize.curve_fit or "lmfit" for the lmfit library. The default is "lmfit".
+        mode : {"lmfit"}, optional
+            The method to use for fitting the Gaussian. Currently only "lmfit" is supported.
         min_flux : astropy.units.Quantity, optional
             Minimum flux required to attempt pointing fit (default: 0.3 Jy).
         reproject_thumbnails : bool, optional

--- a/sotrplib/sources/forced_photometry.py
+++ b/sotrplib/sources/forced_photometry.py
@@ -8,7 +8,6 @@ from astropy.coordinates import SkyCoord
 from astropydantic import AstroPydanticQuantity
 from numpy.typing import ArrayLike
 from pydantic import BaseModel
-from scipy.optimize import curve_fit
 from structlog import get_logger
 from structlog.types import FilteringBoundLogger
 from tqdm import tqdm
@@ -89,257 +88,6 @@ def gaussian_2d_lmfit(
 
     """
     return gaussian_2d((x, y), amplitude, x0, y0, sigma_x, sigma_y, theta, offset)
-
-
-class ScipyGaussian2DFitter:
-    """
-    provide class for fitting a 2D gaussian to a source thumbnail using Scipy's curve_fit.
-
-    Parameters
-    ----------
-    source : MeasuredSource
-        The source object containing the thumbnail to fit.
-    fwhm_guess : AstroPydanticQuantity[u.arcmin], optional
-        Initial guess for the FWHM of the Gaussian, by default u.Quantity(2.2, "arcmin")
-    force_center : bool, optional
-        Whether to force the Gaussian center to be at the thumbnail center, by default False
-    reprojected : bool, optional
-        Whether the thumbnail was reprojected (affects RA offset sign), by default False
-    allowable_center_offset : AstroPydanticQuantity[u.arcmin], optional
-        Maximum allowable offset from the thumbnail center for the fit, by default u.Quantity(1.0, "arcmin")
-    """
-
-    def __init__(
-        self,
-        source: MeasuredSource,
-        fwhm_guess: AstroPydanticQuantity[u.arcmin] = u.Quantity(2.2, "arcmin"),
-        force_center: bool = False,
-        reprojected: bool = False,
-        allowable_center_offset: AstroPydanticQuantity[u.arcmin] = u.Quantity(
-            1.0, "arcmin"
-        ),
-        log: FilteringBoundLogger | None = None,
-    ):
-        self.log = log or get_logger()
-        self.log = self.log.bind(func_name="Gaussian2DFitter")
-        self.source = source
-        self.fwhm_guess = fwhm_guess
-        self.force_center = force_center
-        self.reprojected = reprojected
-        self.allowable_center_offset = allowable_center_offset
-        self.fit_method = "scipy"
-        self.model = None
-
-    def initialize_model(self):
-        """
-        Docstring for initialize_model
-
-        Initialize the 2D Gaussian model and initial parameter guess
-
-        Forcing center removes the x0,y0 from the fit parameters.
-        """
-        self.log.warning(
-            "ScipyGaussian2DFitter.deprecation_warning",
-            warning="Scipy curve fit is being deprecated in favor of lmfit, which provides better handling of parameter constraints and uncertainties. Consider switching to lmfit for improved fitting performance and reliability.",
-        )
-        self.model = gaussian_2d
-        ny, nx = self.source.thumbnail.shape
-        # Define coordinate system centered at the image middle (i.e. the thumbnail center)
-        x = np.arange(nx) - (nx - 1) / 2
-        y = np.arange(ny) - (ny - 1) / 2
-        X, Y = np.meshgrid(x, y)
-        self.X = X
-        self.Y = Y
-        xy = (X.ravel(), Y.ravel())
-        self.xy = xy
-
-        # Initial guess for parameters
-        amplitude_guess = self.source.thumbnail.max()
-        y0_guess, x0_guess = np.unravel_index(
-            np.argmax(self.source.thumbnail), self.source.thumbnail.shape
-        )
-        x0_guess -= (nx - 1) / 2
-        y0_guess -= (ny - 1) / 2
-
-        sigma_guess = (
-            self.fwhm_guess.to(u.arcmin).value
-            / abs(self.source.thumbnail_res.to(u.arcmin).value)
-            / 2.355
-        )  # Rough width estimate, in pixels
-        theta_guess = 0
-        offset_guess = 0
-
-        ## if force center, fix the x0,y0 guesses by not varying them
-        if self.force_center:
-
-            def gaussian_2d_model(xy, amplitude, sigma_x, sigma_y, theta, offset):
-                return gaussian_2d(
-                    xy,
-                    amplitude,
-                    x0_guess,
-                    y0_guess,
-                    sigma_x,
-                    sigma_y,
-                    theta,
-                    offset,
-                )
-
-            initial_guess = [
-                amplitude_guess,
-                sigma_guess[0],
-                sigma_guess[1],
-                theta_guess,
-                offset_guess,
-            ]
-        else:
-            gaussian_2d_model = gaussian_2d
-            initial_guess = [
-                amplitude_guess,
-                x0_guess,
-                y0_guess,
-                sigma_guess[0],
-                sigma_guess[1],
-                theta_guess,
-                offset_guess,
-            ]
-
-        self.model = gaussian_2d_model
-        self.initial_guess = initial_guess
-
-        self.log.debug(
-            "ScipyGaussian2DFitter.model_initialized",
-            fit_method=self.fit_method,
-            model=self.model,
-            initial_guess=self.initial_guess,
-        )
-
-    def fit(self) -> GaussianFitParameters:
-        """
-        Set up and perform the 2D Gaussian fit with Scipy's curve_fit
-
-        sets the MeasuredSource fit_params attribute to the fit results.
-
-        """
-        self.fit_params = GaussianFitParameters()
-        if self.model is None:
-            self.log.error(f"{self.model}_gaussian.model_not_available")
-            self.fit_params.failed = True
-            self.fit_params.failure_reason = "model_not_available"
-            return self.fit_params
-
-        allowable_center_offset_pixels = self.allowable_center_offset.to(
-            u.arcmin
-        ).value / abs(self.source.thumbnail_res.to(u.arcmin).value)
-        ## set bounds if not forcing center
-        bounds = (-np.inf, np.inf)
-        try:
-            if not self.force_center:
-                bounds = (
-                    [
-                        -np.inf,
-                        self.initial_guess[1] - allowable_center_offset_pixels[0],
-                        self.initial_guess[2] - allowable_center_offset_pixels[1],
-                        0,
-                        0,
-                        0,
-                        -np.inf,
-                    ],
-                    [
-                        np.inf,
-                        self.initial_guess[1] + allowable_center_offset_pixels[0],
-                        self.initial_guess[2] + allowable_center_offset_pixels[1],
-                        np.inf,
-                        np.inf,
-                        np.pi,
-                        np.inf,
-                    ],
-                )
-            popt, pcov = curve_fit(
-                self.model,
-                self.xy,
-                self.source.thumbnail.ravel(),
-                p0=self.initial_guess,
-                bounds=bounds,
-            )
-
-        except RuntimeError:
-            self.log.error("curve_fit_2d_gaussian.curve_fit.failed")
-            self.fit_params.failed = True
-            self.fit_params.failure_reason = "curve_fit_runtime_error"
-            return self.fit_params
-
-        perr = np.sqrt(np.diag(pcov))  # Parameter uncertainties
-        self.log.debug("curve_fit_2d_gaussian.curve_fit.success", popt=popt, perr=perr)
-        # Extract parameters and uncertainties
-        if self.force_center:
-            amplitude, sigma_x, sigma_y, theta, offset = popt
-            amplitude_err, sigma_x_err, sigma_y_err, theta_err, offset_err = perr
-            ra_offset, dec_offset = None, None
-            ra_err, dec_err = None, None
-
-        else:
-            amplitude, x0, y0, sigma_x, sigma_y, theta, offset = popt
-            (
-                amplitude_err,
-                x0_err,
-                y0_err,
-                sigma_x_err,
-                sigma_y_err,
-                theta_err,
-                offset_err,
-            ) = perr
-            sign_flip = -1
-            dec_offset = sign_flip * y0 * self.source.thumbnail_res[1]
-            ## if the thumbnail is reprojected or just cut out of the map
-            ## determines the sign of the RA offset and the declination
-            ## correction.
-            ra_offset = sign_flip * x0 * self.source.thumbnail_res[0]
-            if not self.reprojected:
-                ra_offset *= math.cos(self.source.dec.to(u.rad).value)
-            if ra_offset > 180.0 * u.deg:
-                ra_offset -= 360.0 * u.deg
-            elif ra_offset < -180.0 * u.deg:
-                ra_offset += 360.0 * u.deg
-
-            ra_err = x0_err * abs(self.source.thumbnail_res[0])
-            dec_err = y0_err * abs(self.source.thumbnail_res[1])
-
-        fwhm_x = 2.355 * sigma_x * abs(self.source.thumbnail_res[0])
-        fwhm_y = 2.355 * sigma_y * abs(self.source.thumbnail_res[1])
-        fwhm_x_err = 2.355 * sigma_x_err * abs(self.source.thumbnail_res[0])
-        fwhm_y_err = 2.355 * sigma_y_err * abs(self.source.thumbnail_res[1])
-        ## effectively set offset to zero
-        amplitude = AstroPydanticQuantity(
-            amplitude + offset, self.source.thumbnail_unit
-        )
-        amplitude_err = AstroPydanticQuantity(
-            np.sqrt(amplitude_err**2 + offset_err**2), self.source.thumbnail_unit
-        )
-        y_fit = self.model(self.xy, *popt)
-        ss_res = np.sum((self.source.thumbnail.ravel() - y_fit) ** 2)
-        ss_tot = np.sum(
-            (self.source.thumbnail.ravel() - np.mean(self.source.thumbnail.ravel()))
-            ** 2
-        )
-        rsquared = 1 - (ss_res / ss_tot)
-
-        self.fit_params = GaussianFitParameters(
-            amplitude=amplitude,
-            amplitude_err=amplitude_err,
-            ra_offset=ra_offset,
-            ra_err=ra_err,
-            dec_offset=dec_offset,
-            dec_err=dec_err,
-            fwhm_ra=fwhm_x,
-            fwhm_dec=fwhm_y,
-            fwhm_ra_err=fwhm_x_err,
-            fwhm_dec_err=fwhm_y_err,
-            theta=theta * u.rad,
-            theta_err=theta_err * u.rad,
-            forced_center=self.force_center,
-            goodness_of_fit=rsquared,
-        )
-        return self.fit_params
 
 
 class LmFitGaussian2DFitter:
@@ -587,7 +335,7 @@ def gaussian_fit(
     debug: bool = False,
 ) -> list[MeasuredSource]:
     """
-    Fit 2D Gaussian models to a list of registered sources on a map using SciPy.
+    Fit 2D Gaussian models to a list of registered sources on a map using lmfit.
     Parameters
     ----------
     input_map : ProcessableMap
@@ -597,8 +345,8 @@ def gaussian_fit(
         List of registered source objects whose positions are used as initial
         guesses for the Gaussian fits.
     fit_method : str, optional
-        Method to use for fitting the Gaussian. Options are "scipy" for
-        scipy.optimize.curve_fit or "lmfit" for the lmfit library. The default is "lmfit".
+        Kept for backwards compatibility; accepts any value but is ignored.
+        lmfit is always used for fitting.
     flux_lim_fit_centroid : astropy.units.Quantity, optional
         Minimum peak flux density used to decide whether to fit for the source
         centroid. Sources with peak flux below this limit may have their
@@ -643,12 +391,12 @@ def gaussian_fit(
     """
     log = log or get_logger()
 
-    log = log.bind(func_name=f"{fit_method}_2d_gaussian_fit")
-    preamble = f"sources.fitting.{fit_method}_2d_gaussian_fit."
+    log = log.bind(func_name="lmfit_2d_gaussian_fit")
+    preamble = "sources.fitting.lmfit_2d_gaussian_fit."
     fit_sources = []
     for i in tqdm(
         range(len(source_list)),
-        desc=f"Cutting thumbnails and fitting sources w 2D Gaussian ({fit_method})",
+        desc="Cutting thumbnails and fitting sources w 2D Gaussian (lmfit)",
     ):
         source = source_list[i]
 
@@ -686,7 +434,7 @@ def gaussian_fit(
             array=input_map.array,
             frequency=get_frequency(input_map.frequency),
             flags=source_flags,
-            fit_method=f"{fit_method}_2d_gaussian",
+            fit_method="lmfit_2d_gaussian",
             crossmatches=[
                 CrossMatch(
                     ra=source.ra,
@@ -761,10 +509,7 @@ def gaussian_fit(
             fit_sources.append(forced_source)
             continue
 
-        fitfunc = (
-            ScipyGaussian2DFitter if fit_method == "scipy" else LmFitGaussian2DFitter
-        )
-        fitter = fitfunc(
+        fitter = LmFitGaussian2DFitter(
             forced_source,
             reprojected=reproject_thumb,
             fwhm_guess=fwhm

--- a/sotrplib/sources/sources.py
+++ b/sotrplib/sources/sources.py
@@ -116,7 +116,6 @@ class MeasuredSource(RegisteredSource):
     array: str | None = None
 
     fit_method: Literal[
-        "scipy_2d_gaussian",
         "lmfit_2d_gaussian",
         "nearest_neighbor",
         "spline",

--- a/tests/test_forced_photometry/test_forced_photometry.py
+++ b/tests/test_forced_photometry/test_forced_photometry.py
@@ -39,52 +39,6 @@ def test_empty_forced_photometry(map_with_single_source):
     assert results == []
 
 
-def test_scipy_curve_fit(map_with_single_source):
-    input_map, sources = map_with_single_source
-    forced_photometry = TwoDGaussianFitter(
-        mode="scipy", thumbnail_half_width=0.1 * u.deg
-    )
-    source_cat = RegisteredSourceCatalog(sources=[])
-    source_cat.add_sources(sources=sources)
-    source_cat.valid_fluxes = [s.source_id for s in sources]
-    results = forced_photometry.force(input_map=input_map, catalogs=[source_cat])
-    assert results[0].crossmatches
-    assert len(results) == 1
-    ntries = 10
-    if results[0].fit_failed:
-        while results[0].fit_failed and ntries > 0:
-            results = forced_photometry.force(
-                input_map=input_map, catalogs=[source_cat]
-            )
-            ntries -= 1
-
-    assert results[0].flux.to(u.Jy).value == pytest.approx(
-        sources[0].flux.to(u.Jy).value, rel=2e-1
-    )
-    assert results[0].offset_ra.to(u.arcmin).value < 0.5
-    assert results[0].offset_dec.to(u.arcmin).value < 0.5
-    assert results[0].fit_method == "scipy_2d_gaussian"
-
-
-def test_source_offset(map_with_single_source):
-    input_map, sources = map_with_single_source
-    forced_photometry = TwoDGaussianFitter(mode="scipy", reproject_thumbnails=False)
-
-    ra_offset = 0.02 * u.deg
-    new_sources = [x.model_copy() for x in sources]
-    new_sources[0].ra += ra_offset
-
-    catalog = RegisteredSourceCatalog(sources=[])
-    catalog.add_sources(sources=new_sources)
-    catalog.valid_fluxes = [s.source_id for s in new_sources]
-    results = forced_photometry.force(input_map=input_map, catalogs=[catalog])
-    assert len(results) == 1
-    assert not results[0].fit_failed
-    assert results[0].offset_ra.to(u.arcmin).value == pytest.approx(
-        ra_offset.to(u.arcmin).value, abs=0.5
-    )
-
-
 def test_lmfit(map_with_single_source):
     input_map, sources = map_with_single_source
     forced_photometry = TwoDGaussianFitter(mode="lmfit")

--- a/tests/test_pointing/test_pointing.py
+++ b/tests/test_pointing/test_pointing.py
@@ -16,7 +16,7 @@ from sotrplib.sources.sources import MeasuredSource
 def test_median_residual_empty(map_with_single_source):
     input_map, sources = map_with_single_source
     forced_photometry = TwoDGaussianFitter(
-        mode="scipy",
+        mode="lmfit",
         flux_limit_centroid=0.1 * u.Jy,
         reproject_thumbnails=False,
         thumbnail_half_width=10.0 * u.arcmin,
@@ -42,7 +42,7 @@ def test_median_residual_empty(map_with_single_source):
 def test_median_residual_notenough_sources(map_with_single_source):
     input_map, sources = map_with_single_source
     forced_photometry = TwoDGaussianFitter(
-        mode="scipy",
+        mode="lmfit",
         flux_limit_centroid=0.1 * u.Jy,
         reproject_thumbnails=False,
         thumbnail_half_width=10.0 * u.arcmin,
@@ -68,7 +68,7 @@ def test_median_residual_notenough_sources(map_with_single_source):
 def test_median_residual(map_with_sources):
     input_map, sources = map_with_sources
     pointing_fitter = TwoDGaussianPointingFitter(
-        mode="scipy",
+        mode="lmfit",
         min_flux=0.1 * u.Jy,
         reproject_thumbnails=True,
         thumbnail_half_width=10.0 * u.arcmin,
@@ -186,7 +186,7 @@ def test_polynomial_pointing_order1_linear_offset():
 def test_mean_residual(map_with_sources):
     input_map, sources = map_with_sources
     pointing_fitter = TwoDGaussianPointingFitter(
-        mode="scipy",
+        mode="lmfit",
         min_flux=0.1 * u.Jy,
         reproject_thumbnails=True,
         thumbnail_half_width=10.0 * u.arcmin,

--- a/tests/test_prefect_pipeline/conftest.py
+++ b/tests/test_prefect_pipeline/conftest.py
@@ -5,6 +5,6 @@ Fixtures for the dependency-injected completely simulated pipeline.
 import pytest
 
 
-@pytest.fixture(params=["scipy", "lmfit"])
+@pytest.fixture(params=["lmfit"])
 def fit_mode(request):
     return request.param

--- a/tests/test_simulation_pipeline/test_pipeline.py
+++ b/tests/test_simulation_pipeline/test_pipeline.py
@@ -19,7 +19,7 @@ def test_created_map(empty_map: SimulatedMap):
     assert isinstance(empty_map, SimulatedMap)
 
 
-def test_injected_sources_scipy(
+def test_injected_sources_lmfit(
     map_with_sources: tuple[SimulatedMap, list[RegisteredSource]],
 ):
     new_map, sources = map_with_sources
@@ -28,41 +28,9 @@ def test_injected_sources_scipy(
     assert len(sources) > 0
 
     # See if we can recover them
-    forced_sources = gaussian_fit(new_map, source_list=sources, fit_method="scipy")
+    forced_sources = gaussian_fit(new_map, source_list=sources, fit_method="lmfit")
 
     assert len(forced_sources) == len(sources)
-
-
-def test_basic_pipeline_scipy(
-    tmp_path, map_with_sources: tuple[SimulatedMap, list[RegisteredSource]]
-):
-    """
-    Tests a complete setup of the basic pipeline run.
-    """
-
-    new_map, sources = map_with_sources
-    source_cat = RegisteredSourceCatalog(sources=sources)
-    maps = [new_map, new_map]
-
-    runner = PipelineRunner(
-        map_coadder=None,
-        source_catalogs=[source_cat],
-        sso_catalogs=[],
-        source_injector=None,
-        preprocessors=None,
-        pointing_provider=None,
-        pointing_residual_model=None,
-        postprocessors=None,
-        source_simulators=None,
-        forced_photometry=TwoDGaussianFitter(mode="scipy"),
-        source_subtractor=None,
-        blind_search=SigmaClipBlindSearch(),
-        sifter=DefaultSifter(),
-        source_outputs=[PickleSerializer(directory=tmp_path)],
-        map_outputs=None,
-    )
-
-    runner.run(maps)
 
 
 def test_basic_pipeline_lmfit(


### PR DESCRIPTION
:robot: done using copilot

remove the deprecated scipy curve fit version of the 2D gaussian fitter.

Agent-Logs-Url: https://github.com/simonsobs/sotrplib/sessions/c190dcb2-0d59-4b84-8ebb-caa8604f4aa4