### PR TITLE
Refactor bbox

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sotrplib"
-version = "0.0.1a1"
-requires-python = ">=3.11"
+version = "0.0.2"
+requires-python = ">=3.12"
 dependencies = [
     "pixell",
     "numpy==1.26.4",

--- a/sotrplib/config/maps.py
+++ b/sotrplib/config/maps.py
@@ -113,7 +113,7 @@ class RhoKappaMapConfig(MapConfig):
     instrument: str | None = None
     observation_start: AwareDatetime | None = None
     observation_end: AwareDatetime | None = None
-    box: list[AstroPydanticICRS] | None = None
+    sky_box: list[AstroPydanticICRS] | None = None
     flux_units: AstroPydanticUnit = u.Unit("Jy")
 
     def to_map(self, log: FilteringBoundLogger | None = None) -> RhoAndKappaMap:
@@ -124,7 +124,7 @@ class RhoKappaMapConfig(MapConfig):
             end_time=self.observation_end,
             time_filename=self.time_map_path,
             info_filename=self.info_path,
-            box=self.box,
+            sky_box=self.sky_box,
             frequency=self.frequency,
             array=self.array,
             instrument=self.instrument,
@@ -144,7 +144,7 @@ class InverseVarianceMapConfig(MapConfig):
     instrument: str | None = None
     observation_start: AwareDatetime | None = None
     observation_end: AwareDatetime | None = None
-    box: list[AstroPydanticICRS] | None = None
+    sky_box: list[AstroPydanticICRS] | None = None
     intensity_units: AstroPydanticUnit = u.Unit("K")
 
     def to_map(
@@ -157,7 +157,7 @@ class InverseVarianceMapConfig(MapConfig):
             info_filename=self.info_path,
             start_time=self.observation_start,
             end_time=self.observation_end,
-            box=self.box,
+            sky_box=self.sky_box,
             frequency=self.frequency,
             array=self.array,
             instrument=self.instrument,
@@ -177,7 +177,7 @@ class FluxAndSNRMapConfig(MapConfig):
     instrument: str | None = None
     observation_start: AwareDatetime | None = None
     observation_end: AwareDatetime | None = None
-    box: list[AstroPydanticICRS] | None = None
+    sky_box: list[AstroPydanticICRS] | None = None
     flux_units: AstroPydanticUnit = u.Unit("Jy")
 
     def to_map(self, log: FilteringBoundLogger | None = None) -> FluxAndSNRMap:
@@ -188,7 +188,7 @@ class FluxAndSNRMapConfig(MapConfig):
             info_filename=self.info_path,
             start_time=self.observation_start,
             end_time=self.observation_end,
-            box=self.box,
+            sky_box=self.sky_box,
             frequency=self.frequency,
             array=self.array,
             instrument=self.instrument,
@@ -206,7 +206,7 @@ class MapCatDatabaseConfig(MapGeneratorConfig):
     start_time: AwareDatetime | None = None
     end_time: AwareDatetime | None = None
     map_ids: list[int] | None = None
-    box: list[AstroPydanticICRS] | None = None
+    sky_box: list[AstroPydanticICRS] | None = None
     map_units: AstroPydanticUnit = u.Unit("K")
     map_type: Literal["intensity", "flux", "rhokappa"] = "intensity"
     rerun: bool = False
@@ -226,7 +226,7 @@ class MapCatDatabaseConfig(MapGeneratorConfig):
             frequency=self.frequency,
             array=self.array,
             instrument=self.instrument,
-            box=self.box,
+            sky_box=self.sky_box,
             map_ids=self.map_ids,
             map_units=self.map_units,
             rerun=self.rerun,

--- a/sotrplib/handlers/base.py
+++ b/sotrplib/handlers/base.py
@@ -3,8 +3,6 @@ from itertools import combinations
 from typing import Iterable
 
 import numpy as np
-from astropy import units
-from astropy.coordinates import SkyCoord
 from mapcat.pointing.const import ConstantPointingModel
 from mapcat.pointing.poly import PolynomialPointingModel
 
@@ -18,6 +16,7 @@ from sotrplib.maps.pointing import (
 )
 from sotrplib.maps.postprocessor import MapPostprocessor
 from sotrplib.maps.preprocessor import MapPreprocessor
+from sotrplib.maps.utils import enmap_box_to_skycoord
 from sotrplib.outputs.core import MapOutput, SourceOutput
 from sotrplib.sifter.core import EmptySifter, SifterResult, SiftingProvider
 from sotrplib.sifter.crossmatch import crossmatch_mask, n_wise_crossmatch
@@ -131,19 +130,16 @@ class BaseRunner:
         if not maps:
             return None
 
-        # mapcat map list is not subscriptable so start with maximal bounding box
-        bbox = [
-            SkyCoord(ra=359.999 * units.deg, dec=90.0 * units.deg),
-            SkyCoord(ra=0.0 * units.deg, dec=-90.0 * units.deg),
-        ]
+        # map.bbox returns a pixell box [[dec_min, ra_max], [dec_max, ra_min]] in radians
+        dec_min, ra_max = np.pi / 2, 0.0
+        dec_max, ra_min = -np.pi / 2, 2 * np.pi
         for input_map in maps:
-            map_bbox = input_map.bbox
-            left = min(bbox[0].ra, map_bbox[0].ra)
-            bottom = min(bbox[0].dec, map_bbox[0].dec)
-            right = max(bbox[1].ra, map_bbox[1].ra)
-            top = max(bbox[1].dec, map_bbox[1].dec)
-            bbox = [SkyCoord(ra=left, dec=bottom), SkyCoord(ra=right, dec=top)]
-        return bbox
+            b = input_map.bbox  # [[dec_min, ra_max], [dec_max, ra_min]]
+            dec_min = min(dec_min, b[0][0], b[1][0])
+            dec_max = max(dec_max, b[0][0], b[1][0])
+            ra_min = min(ra_min, b[0][1], b[1][1])
+            ra_max = max(ra_max, b[0][1], b[1][1])
+        return [[dec_min, ra_max], [dec_max, ra_min]]
 
     def observation_time_range(self, maps=None):
         if not maps:
@@ -157,16 +153,15 @@ class BaseRunner:
 
         return (start_time, end_time)
 
-    def simulate_sources(
-        self, bbox: list[SkyCoord], time_range: tuple[float]
-    ) -> list[SimulatedSource]:
+    def simulate_sources(self, bbox, time_range: tuple[float]) -> list[SimulatedSource]:
         """Generate sources based upon maximal bounding box of all maps"""
         if len(self.source_simulators) == 0:
             return []
+        sky_box = enmap_box_to_skycoord(bbox) if bbox is not None else None
         all_simulated_sources = []
         for simulator in self.source_simulators:
             simulated_sources, catalog = self.profilable_task(simulator.generate)(
-                box=bbox,
+                box=sky_box,
                 time_range=time_range,
             )
 

--- a/sotrplib/handlers/base.py
+++ b/sotrplib/handlers/base.py
@@ -161,7 +161,7 @@ class BaseRunner:
         all_simulated_sources = []
         for simulator in self.source_simulators:
             simulated_sources, catalog = self.profilable_task(simulator.generate)(
-                box=sky_box,
+                sky_box=sky_box,
                 time_range=time_range,
             )
 

--- a/sotrplib/handlers/base.py
+++ b/sotrplib/handlers/base.py
@@ -16,7 +16,7 @@ from sotrplib.maps.pointing import (
 )
 from sotrplib.maps.postprocessor import MapPostprocessor
 from sotrplib.maps.preprocessor import MapPreprocessor
-from sotrplib.maps.utils import enmap_box_to_skycoord
+from sotrplib.maps.utils import Box, enmap_box_to_skycoord
 from sotrplib.outputs.core import MapOutput, SourceOutput
 from sotrplib.sifter.core import EmptySifter, SifterResult, SiftingProvider
 from sotrplib.sifter.crossmatch import crossmatch_mask, n_wise_crossmatch
@@ -128,23 +128,22 @@ class BaseRunner:
 
     def extract_bounding_box(
         self, maps: list[ProcessableMap] | None = None
-    ) -> list[list[float], list[float]] | None:
+    ) -> Box | None:
         if not maps:
             return None
 
-        # map.bbox returns a pixell box [[dec_min, ra_max], [dec_max, ra_min]] in radians
-        # so set defaults so that any real map will update them.
+        # set defaults so that any real map will update them.
         dec_min = np.inf
         dec_max = -np.inf
         ra_min = np.inf
         ra_max = -np.inf
         for input_map in maps:
-            b = input_map.bbox
+            b = input_map.bbox  # map.bbox returns a pixell box [[dec_min, ra_max], [dec_max, ra_min]] in radians
             dec_min = min(dec_min, b[0][0], b[1][0])
             dec_max = max(dec_max, b[0][0], b[1][0])
             ra_min = min(ra_min, b[0][1], b[1][1])
             ra_max = max(ra_max, b[0][1], b[1][1])
-        return [[dec_min, ra_max], [dec_max, ra_min]]
+        return np.array([[dec_min, ra_max], [dec_max, ra_min]])
 
     def observation_time_range(self, maps=None):
         if not maps:
@@ -158,7 +157,9 @@ class BaseRunner:
 
         return (start_time, end_time)
 
-    def simulate_sources(self, bbox, time_range: tuple[float]) -> list[SimulatedSource]:
+    def simulate_sources(
+        self, bbox: Box | None, time_range: tuple[float]
+    ) -> list[SimulatedSource]:
         """Generate sources based upon maximal bounding box of all maps"""
         if len(self.source_simulators) == 0:
             return []

--- a/sotrplib/handlers/base.py
+++ b/sotrplib/handlers/base.py
@@ -126,15 +126,20 @@ class BaseRunner:
     def coadd_maps(self, input_maps: list[ProcessableMap]) -> list[ProcessableMap]:
         return self.map_coadder.coadd(input_maps)
 
-    def bbox(self, maps=None):
+    def extract_bounding_box(
+        self, maps: list[ProcessableMap] | None = None
+    ) -> list[list[float], list[float]] | None:
         if not maps:
             return None
 
         # map.bbox returns a pixell box [[dec_min, ra_max], [dec_max, ra_min]] in radians
-        dec_min, ra_max = np.pi / 2, 0.0
-        dec_max, ra_min = -np.pi / 2, 2 * np.pi
+        # so set defaults so that any real map will update them.
+        dec_min = np.inf
+        dec_max = -np.inf
+        ra_min = np.inf
+        ra_max = -np.inf
         for input_map in maps:
-            b = input_map.bbox  # [[dec_min, ra_max], [dec_max, ra_min]]
+            b = input_map.bbox
             dec_min = min(dec_min, b[0][0], b[1][0])
             dec_max = max(dec_max, b[0][0], b[1][0])
             ra_min = min(ra_min, b[0][1], b[1][1])
@@ -298,7 +303,7 @@ class BaseRunner:
         The actual pipeline run logic has to be in a separate method so that it can be
         decorated with the flow as prefect needs these to be defined in advance.
         """
-        bbox = self.bbox(maps)
+        bbox = self.extract_bounding_box(maps)
         time_range = self.observation_time_range(maps)
         all_simulated_sources = self.basic_task(self.simulate_sources)(bbox, time_range)
         map_sets = self.basic_task(self.map_coadder.group_maps)(maps)

--- a/sotrplib/handlers/base.py
+++ b/sotrplib/handlers/base.py
@@ -3,6 +3,7 @@ from itertools import combinations
 from typing import Iterable
 
 import numpy as np
+from astropy.coordinates import SkyCoord
 from mapcat.pointing.const import ConstantPointingModel
 from mapcat.pointing.poly import PolynomialPointingModel
 
@@ -16,7 +17,7 @@ from sotrplib.maps.pointing import (
 )
 from sotrplib.maps.postprocessor import MapPostprocessor
 from sotrplib.maps.preprocessor import MapPreprocessor
-from sotrplib.maps.utils import Box, enmap_box_to_skycoord
+from sotrplib.maps.utils import enmap_box_to_skycoord
 from sotrplib.outputs.core import MapOutput, SourceOutput
 from sotrplib.sifter.core import EmptySifter, SifterResult, SiftingProvider
 from sotrplib.sifter.crossmatch import crossmatch_mask, n_wise_crossmatch
@@ -128,7 +129,7 @@ class BaseRunner:
 
     def extract_bounding_box(
         self, maps: list[ProcessableMap] | None = None
-    ) -> Box | None:
+    ) -> tuple[SkyCoord, SkyCoord] | None:
         if not maps:
             return None
 
@@ -143,7 +144,9 @@ class BaseRunner:
             dec_max = max(dec_max, b[0][0], b[1][0])
             ra_min = min(ra_min, b[0][1], b[1][1])
             ra_max = max(ra_max, b[0][1], b[1][1])
-        return np.array([[dec_min, ra_max], [dec_max, ra_min]])
+        bbox = np.array([[dec_min, ra_max], [dec_max, ra_min]])
+        sky_box = enmap_box_to_skycoord(bbox)
+        return sky_box
 
     def observation_time_range(self, maps=None):
         if not maps:
@@ -158,12 +161,11 @@ class BaseRunner:
         return (start_time, end_time)
 
     def simulate_sources(
-        self, bbox: Box | None, time_range: tuple[float]
+        self, sky_box: tuple[SkyCoord, SkyCoord] | None, time_range: tuple[float]
     ) -> list[SimulatedSource]:
         """Generate sources based upon maximal bounding box of all maps"""
         if len(self.source_simulators) == 0:
             return []
-        sky_box = enmap_box_to_skycoord(bbox) if bbox is not None else None
         all_simulated_sources = []
         for simulator in self.source_simulators:
             simulated_sources, catalog = self.profilable_task(simulator.generate)(
@@ -304,9 +306,11 @@ class BaseRunner:
         The actual pipeline run logic has to be in a separate method so that it can be
         decorated with the flow as prefect needs these to be defined in advance.
         """
-        bbox = self.extract_bounding_box(maps)
+        sky_box = self.extract_bounding_box(maps)
         time_range = self.observation_time_range(maps)
-        all_simulated_sources = self.basic_task(self.simulate_sources)(bbox, time_range)
+        all_simulated_sources = self.basic_task(self.simulate_sources)(
+            sky_box, time_range
+        )
         map_sets = self.basic_task(self.map_coadder.group_maps)(maps)
         results = (
             self.basic_task(self.coadd_and_analyze_maps)

--- a/sotrplib/maps/core.py
+++ b/sotrplib/maps/core.py
@@ -116,6 +116,9 @@ class ProcessableMap(ABC):
 
     _pointing_model: PointingModel | None = None
 
+    _available_maps: tuple[str, ...] = ("flux", "snr")
+    "Ordered attribute names searched by bbox to find a loaded map."
+
     @abstractmethod
     def build(self):
         """
@@ -261,17 +264,20 @@ class ProcessableMap(ABC):
         return self.map_resolution
 
     @property
-    @abstractmethod
     def bbox(self) -> np.ndarray:
         """
         The bounding box of the map as a pixell enmap box.
 
-        Returns ``enmap.box(shape, wcs)`` on the primary loaded map — a
-        ``[[dec_min, ra_max], [dec_max, ra_min]]`` array in radians (``ra_min``
-        may be negative for wrapping maps).  If the map has not been built yet,
-        falls back to ``skycoord_box_to_enmap_box(self.sky_box)`` when ``sky_box`` is
-        set, or reads the geometry from the source file.
+        Returns ``enmap.box(shape, wcs)`` on the first loaded map found in
+        ``_available_maps``.  Falls back to ``skycoord_box_to_enmap_box(self.sky_box)``
+        when ``sky_box`` is set.  Returns ``None`` if no map or sky_box is available.
         """
+        for attr in self._available_maps:
+            if (m := getattr(self, attr, None)) is not None:
+                return enmap.box(m.shape, m.wcs)
+        if self.sky_box is not None:
+            return skycoord_box_to_enmap_box(self.sky_box)
+        return None
 
     @property
     def map_id(self) -> str:
@@ -357,6 +363,8 @@ class IntensityAndInverseVarianceMap(ProcessableMap):
     be monthly or weekly co-adds. Or something else!
     """
 
+    _available_maps: tuple[str, ...] = ("intensity",)
+
     def __init__(
         self,
         intensity_filename: Path,
@@ -395,10 +403,8 @@ class IntensityAndInverseVarianceMap(ProcessableMap):
 
     @property
     def bbox(self) -> np.ndarray:
-        if (intensity := getattr(self, "intensity", None)) is not None:
-            return enmap.box(intensity.shape, intensity.wcs)
-        if self.sky_box is not None:
-            return skycoord_box_to_enmap_box(self.sky_box)
+        if (box := super().bbox) is not None:
+            return box
         shape, wcs = enmap.read_map_geometry(str(self.intensity_filename))
         return enmap.box(shape, wcs)
 
@@ -543,6 +549,8 @@ class MatchedFilteredIntensityAndInverseVarianceMap(ProcessableMap):
 
     """
 
+    _available_maps: tuple[str, ...] = ("rho", "kappa", "flux", "snr")
+
     def __init__(
         self,
         rho: enmap.ndmap,
@@ -587,12 +595,6 @@ class MatchedFilteredIntensityAndInverseVarianceMap(ProcessableMap):
             self.prefiltered_intensity = None
             self.prefiltered_inverse_variance = None
             self.intensity_units = None
-
-    @property
-    def bbox(self) -> np.ndarray:
-        for attr in ["rho", "kappa", "flux", "snr"]:
-            if (m := getattr(self, attr, None)) is not None:
-                return enmap.box(m.shape, m.wcs)
 
     def build(self):
         return
@@ -678,6 +680,8 @@ class RhoAndKappaMap(ProcessableMap):
     sky_box is tuple of SkyCoord: (SkyCoord(ra=ra_min, dec=dec_min), SkyCoord(ra=ra_max, dec=dec_max))
     """
 
+    _available_maps: tuple[str, ...] = ("rho", "kappa", "flux", "snr")
+
     def __init__(
         self,
         rho_filename: Path,
@@ -714,11 +718,8 @@ class RhoAndKappaMap(ProcessableMap):
 
     @property
     def bbox(self) -> np.ndarray:
-        for attr in ["rho", "kappa", "flux", "snr"]:
-            if (m := getattr(self, attr, None)) is not None:
-                return enmap.box(m.shape, m.wcs)
-        if self.sky_box is not None:
-            return skycoord_box_to_enmap_box(self.sky_box)
+        if (box := super().bbox) is not None:
+            return box
         shape, wcs = enmap.read_map_geometry(str(self.rho_filename))
         return enmap.box(shape, wcs)
 
@@ -884,10 +885,8 @@ class FluxAndSNRMap(ProcessableMap):
 
     @property
     def bbox(self) -> np.ndarray:
-        if (flux := getattr(self, "flux", None)) is not None:
-            return enmap.box(flux.shape, flux.wcs)
-        if self.sky_box is not None:
-            return skycoord_box_to_enmap_box(self.sky_box)
+        if (box := super().bbox) is not None:
+            return box
         shape, wcs = enmap.read_map_geometry(str(self.flux_filename))
         return enmap.box(shape, wcs)
 
@@ -1013,6 +1012,8 @@ class CoaddedRhoKappaMap(ProcessableMap):
     Coadds are built using map_coadding.MapCoadder classes.
     """
 
+    _available_maps: tuple[str, ...] = ("rho", "kappa", "flux", "snr")
+
     def __init__(
         self,
         rho: ndmap,
@@ -1055,12 +1056,6 @@ class CoaddedRhoKappaMap(ProcessableMap):
         self.map_ids = map_ids
         self.input_map_times = input_map_times
         self.log = log or structlog.get_logger()
-
-    @property
-    def bbox(self) -> np.ndarray:
-        for attr in ["rho", "kappa", "flux", "snr"]:
-            if (m := getattr(self, attr, None)) is not None:
-                return enmap.box(m.shape, m.wcs)
 
     def build(self):
         pass

--- a/sotrplib/maps/core.py
+++ b/sotrplib/maps/core.py
@@ -17,7 +17,7 @@ from pixell.enmap import ndmap
 from pydantic import AwareDatetime
 from structlog.types import FilteringBoundLogger
 
-from sotrplib.maps.utils import pixell_map_union
+from sotrplib.maps.utils import pixell_map_union, skycoord_box_to_enmap_box
 
 PointingModel = ConstantPointingModel
 
@@ -85,7 +85,20 @@ class ProcessableMap(ABC):
     instrument: str | None = None
     "The instrument that observed the map, e.g. 'SOLAT', 'SOSAT'"
 
-    box: tuple[SkyCoord, SkyCoord] | None = None
+    sky_box: tuple[SkyCoord, SkyCoord] | None = None
+    """
+    Sky bounding box. Can be set to initialize the map with a cutout of a larger map.
+    Should be in the form
+
+    ``sky_box = (SkyCoord(ra=ra_min, dec=dec_min), SkyCoord(ra=ra_max, dec=dec_max))``
+
+    Wrap detection (both RAs in ``[0, 2π)``):
+
+    - ``sky_box[0].ra < sky_box[1].ra`` — non-wrapping region.
+    - ``sky_box[0].ra > sky_box[1].ra`` — wrapping region (spans RA = 0);
+      ``sky_box[0].ra`` is the upper boundary (near 2π) and ``sky_box[1].ra`` is the
+      lower boundary (near 0).
+    """
 
     _hits: ndmap | None = None
     "A hits map stating the number of times each pixel was observed"
@@ -248,34 +261,17 @@ class ProcessableMap(ABC):
         return self.map_resolution
 
     @property
-    def bbox(self) -> tuple[SkyCoord, SkyCoord]:
+    @abstractmethod
+    def bbox(self) -> np.ndarray:
         """
-        The bounding box of the map provided as sky coordinates.
+        The bounding box of the map as a pixell enmap box.
+
+        Returns ``enmap.box(shape, wcs)`` on the primary loaded map — a
+        ``[[dec_min, ra_max], [dec_max, ra_min]]`` array in radians (``ra_min``
+        may be negative for wrapping maps).  If the map has not been built yet,
+        falls back to ``skycoord_box_to_enmap_box(self.sky_box)`` when ``sky_box`` is
+        set, or reads the geometry from the source file.
         """
-        ## TODO: do we want the bounding box returned to be the bbox of this specific map
-        ## or the box used to read in the map if it was provided?
-        ## need to check how box works when reading in the maps;
-        """
-        let's say you want to cut a box from -20 to 20 in ra, and -20 to 20 in dec but the map is only from -10, 20 in ra and -20, 10 in dec. 
-        The true bounding box of the cut map would only be (-10,-20),(20,10) but self.box would be (-20,-10),(20,20)
-        not sure if that's how box works when reading in maps or if it fills the empty space with nans or something... should check that
-        """
-        for attribute in ["flux", "snr", "rho", "kappa"]:
-            if (x := getattr(self, attribute, None)) is not None:
-                shape = x.shape[-2:]
-                wcs = x.wcs
-
-                bottom_left = wcs.array_index_to_world(0, 0)
-                top_right = wcs.array_index_to_world(shape[0], shape[1])
-
-                self.box = (
-                    bottom_left,
-                    top_right,
-                )
-
-                break
-
-        return self.box
 
     @property
     def map_id(self) -> str:
@@ -367,7 +363,7 @@ class IntensityAndInverseVarianceMap(ProcessableMap):
         inverse_variance_filename: Path,
         start_time: AwareDatetime,
         end_time: AwareDatetime,
-        box: tuple[SkyCoord, SkyCoord] | None = None,
+        sky_box: tuple[SkyCoord, SkyCoord] | None = None,
         time_filename: Path | None = None,
         info_filename: Path | None = None,
         frequency: str | None = None,
@@ -386,7 +382,7 @@ class IntensityAndInverseVarianceMap(ProcessableMap):
         self.info_filename = info_filename
         self.observation_start = start_time
         self.observation_end = end_time
-        self.box = box
+        self.sky_box = sky_box
         self.frequency = frequency
         self.array = array
         self.instrument = instrument
@@ -398,39 +394,23 @@ class IntensityAndInverseVarianceMap(ProcessableMap):
         self.log = log or structlog.get_logger()
 
     @property
-    def bbox(self) -> tuple[SkyCoord, SkyCoord]:
-        """
-        The bounding box of the map provided as sky coordinates.
-        Read from the inverse variance map header.
-
-        if self.box is set, return that instead.
-        """
-        if self.box is not None:
-            return self.box
-
+    def bbox(self) -> np.ndarray:
+        if (intensity := getattr(self, "intensity", None)) is not None:
+            return enmap.box(intensity.shape, intensity.wcs)
+        if self.sky_box is not None:
+            return skycoord_box_to_enmap_box(self.sky_box)
         shape, wcs = enmap.read_map_geometry(str(self.intensity_filename))
-
-        bottom_left = wcs.array_index_to_world(0, 0)
-        top_right = wcs.array_index_to_world(shape[-2], shape[-1])
-
-        self.box = (bottom_left, top_right)
-        return self.box
+        return enmap.box(shape, wcs)
 
     def build(self):
-        log = self.log.bind(intensity_filename=self.intensity_filename, box=self.box)
-        # box = self.box.to(u.rad).value if self.box is not None else None
+        log = self.log.bind(
+            intensity_filename=self.intensity_filename, sky_box=self.sky_box
+        )
         enmap_box = (
-            [
-                [self.box[0].dec.to_value(u.rad), self.box[1].ra.to_value(u.rad)],
-                [self.box[1].dec.to_value(u.rad), self.box[0].ra.to_value(u.rad)],
-            ]
-            if self.box is not None
+            skycoord_box_to_enmap_box(self.sky_box)
+            if self.sky_box is not None
             else None
         )
-
-        if enmap_box is not None:
-            if enmap_box[0][1] < enmap_box[1][1]:
-                enmap_box[1][1] -= 2 * np.pi
         intensity_shape = enmap.read_map_geometry(str(self.intensity_filename))[0]
         self.intensity = enmap.read_map(
             str(self.intensity_filename),
@@ -586,7 +566,7 @@ class MatchedFilteredIntensityAndInverseVarianceMap(ProcessableMap):
             self.prefiltered_map.observation_end
             - self.prefiltered_map.observation_start
         )
-        self.box = self.prefiltered_map.box
+        self.sky_box = self.prefiltered_map.sky_box
         self.frequency = self.prefiltered_map.frequency
         self.array = self.prefiltered_map.array
         self.mask = self.prefiltered_map.mask
@@ -607,6 +587,12 @@ class MatchedFilteredIntensityAndInverseVarianceMap(ProcessableMap):
             self.prefiltered_intensity = None
             self.prefiltered_inverse_variance = None
             self.intensity_units = None
+
+    @property
+    def bbox(self) -> np.ndarray:
+        for attr in ["rho", "kappa", "flux", "snr"]:
+            if (m := getattr(self, attr, None)) is not None:
+                return enmap.box(m.shape, m.wcs)
 
     def build(self):
         return
@@ -689,7 +675,7 @@ class RhoAndKappaMap(ProcessableMap):
     A set of FITS maps read from disk. Could be Depth 1, could
     be monthly or weekly co-adds. Or something else!
 
-    box is array of astropy Quantities: [[dec_min, ra_min], [dec_max, ra_max]]
+    sky_box is tuple of SkyCoord: (SkyCoord(ra=ra_min, dec=dec_min), SkyCoord(ra=ra_max, dec=dec_max))
     """
 
     def __init__(
@@ -698,7 +684,7 @@ class RhoAndKappaMap(ProcessableMap):
         kappa_filename: Path,
         start_time: AwareDatetime,
         end_time: AwareDatetime,
-        box: tuple[SkyCoord, SkyCoord] | None = None,
+        sky_box: tuple[SkyCoord, SkyCoord] | None = None,
         time_filename: Path | None = None,
         info_filename: Path | None = None,
         frequency: str | None = None,
@@ -715,7 +701,7 @@ class RhoAndKappaMap(ProcessableMap):
         self.info_filename = info_filename
         self.observation_start = start_time
         self.observation_end = end_time
-        self.box = box
+        self.sky_box = sky_box
         self.frequency = frequency
         self.array = array
         self.instrument = instrument
@@ -727,35 +713,22 @@ class RhoAndKappaMap(ProcessableMap):
         self.log = log or structlog.get_logger()
 
     @property
-    def bbox(self) -> tuple[SkyCoord, SkyCoord]:
-        """
-        The bounding box of the map provided as sky coordinates.
-        Read from the rho map header.
-        """
-        if self.box is not None:
-            return self.box
-
+    def bbox(self) -> np.ndarray:
+        for attr in ["rho", "kappa", "flux", "snr"]:
+            if (m := getattr(self, attr, None)) is not None:
+                return enmap.box(m.shape, m.wcs)
+        if self.sky_box is not None:
+            return skycoord_box_to_enmap_box(self.sky_box)
         shape, wcs = enmap.read_map_geometry(str(self.rho_filename))
-
-        bottom_left = wcs.array_index_to_world(0, 0)
-        top_right = wcs.array_index_to_world(shape[-2], shape[-1])
-
-        self.box = (bottom_left, top_right)
-        return self.box
+        return enmap.box(shape, wcs)
 
     def build(self):
         log = self.log.bind(rho_filename=self.rho_filename)
         enmap_box = (
-            [
-                [self.box[0].dec.to_value(u.rad), self.box[0].ra.to_value(u.rad)],
-                [self.box[1].dec.to_value(u.rad), self.box[1].ra.to_value(u.rad)],
-            ]
-            if self.box is not None
+            skycoord_box_to_enmap_box(self.sky_box)
+            if self.sky_box is not None
             else None
         )
-        if enmap_box is not None:
-            if enmap_box[0][1] < enmap_box[1][1]:
-                enmap_box[1][1] -= 2 * np.pi
         try:
             self.rho = enmap.read_map(str(self.rho_filename), sel=0, box=enmap_box)
             assert type(self.rho) is enmap.ndmap
@@ -872,7 +845,7 @@ class FluxAndSNRMap(ProcessableMap):
     A set of FITS maps read from disk. Could be Depth 1, could
     be monthly or weekly co-adds. Or something else!
 
-    box is tuple of skycoords: (bottom_left, top_right)
+    sky_box is tuple of skycoords: (SkyCoord(ra=ra_min, dec=dec_min), SkyCoord(ra=ra_max, dec=dec_max))
     """
 
     def __init__(
@@ -881,7 +854,7 @@ class FluxAndSNRMap(ProcessableMap):
         snr_filename: Path,
         start_time: AwareDatetime,
         end_time: AwareDatetime,
-        box: tuple[SkyCoord, SkyCoord] | None = None,
+        sky_box: tuple[SkyCoord, SkyCoord] | None = None,
         time_filename: Path | None = None,
         info_filename: Path | None = None,
         frequency: str | None = None,
@@ -898,7 +871,7 @@ class FluxAndSNRMap(ProcessableMap):
         self.info_filename = info_filename
         self.observation_start = start_time
         self.observation_end = end_time
-        self.box = box
+        self.sky_box = sky_box
         self.frequency = frequency
         self.array = array
         self.instrument = instrument
@@ -910,35 +883,21 @@ class FluxAndSNRMap(ProcessableMap):
         self.log = log or structlog.get_logger()
 
     @property
-    def bbox(self) -> tuple[SkyCoord, SkyCoord]:
-        """
-        The bounding box of the map provided as sky coordinates.
-        Read from the flux map header.
-        """
-        if self.box is not None:
-            return self.box
-
+    def bbox(self) -> np.ndarray:
+        if (flux := getattr(self, "flux", None)) is not None:
+            return enmap.box(flux.shape, flux.wcs)
+        if self.sky_box is not None:
+            return skycoord_box_to_enmap_box(self.sky_box)
         shape, wcs = enmap.read_map_geometry(str(self.flux_filename))
-
-        bottom_left = wcs.array_index_to_world(0, 0)
-        top_right = wcs.array_index_to_world(shape[-2], shape[-1])
-
-        self.box = (bottom_left, top_right)
-        return self.box
+        return enmap.box(shape, wcs)
 
     def build(self):
         log = self.log.bind(flux_filename=self.flux_filename)
         enmap_box = (
-            [
-                [self.box[0].dec.to_value(u.rad), self.box[0].ra.to_value(u.rad)],
-                [self.box[1].dec.to_value(u.rad), self.box[1].ra.to_value(u.rad)],
-            ]
-            if self.box is not None
+            skycoord_box_to_enmap_box(self.sky_box)
+            if self.sky_box is not None
             else None
         )
-        if enmap_box is not None:
-            if enmap_box[0][1] < enmap_box[1][1]:
-                enmap_box[1][1] -= 2 * np.pi
         try:
             self.flux = enmap.read_map(str(self.flux_filename), sel=0, box=enmap_box)
             assert type(self.flux) is enmap.ndmap
@@ -1064,7 +1023,7 @@ class CoaddedRhoKappaMap(ProcessableMap):
         time_mean: ndmap | None = None,
         time_last: ndmap | None = None,
         observation_length: timedelta | None = None,
-        box: tuple[SkyCoord, SkyCoord] | None = None,
+        sky_box: tuple[SkyCoord, SkyCoord] | None = None,
         frequency: str | None = None,
         array: str | None = None,
         instrument: str | None = None,
@@ -1085,7 +1044,7 @@ class CoaddedRhoKappaMap(ProcessableMap):
         self.observation_end = observation_end
         self.observation_length = observation_length
         self.observation_time = observation_end - 0.5 * observation_length
-        self.box = box
+        self.sky_box = sky_box
         self.frequency = frequency
         self.array = array
         self.instrument = instrument
@@ -1096,6 +1055,12 @@ class CoaddedRhoKappaMap(ProcessableMap):
         self.map_ids = map_ids
         self.input_map_times = input_map_times
         self.log = log or structlog.get_logger()
+
+    @property
+    def bbox(self) -> np.ndarray:
+        for attr in ["rho", "kappa", "flux", "snr"]:
+            if (m := getattr(self, attr, None)) is not None:
+                return enmap.box(m.shape, m.wcs)
 
     def build(self):
         pass

--- a/sotrplib/maps/database.py
+++ b/sotrplib/maps/database.py
@@ -52,7 +52,7 @@ class MapCatDatabaseReader(ABC):
     end_time: AwareDatetime | None = None
     map_ids: list[int] | None = None
     sources: list[RegisteredSource] | None = None
-    box: tuple[SkyCoord, SkyCoord] | None = None
+    sky_box: tuple[SkyCoord, SkyCoord] | None = None
     intensity_units: u.Unit = u.Unit("K")
     rerun: bool = False
     log: FilteringBoundLogger
@@ -69,7 +69,7 @@ class MapCatDatabaseReader(ABC):
         frequency: str | None = None,
         array: str | None = None,
         instrument: str | None = None,
-        box: tuple[SkyCoord, SkyCoord] | None = None,
+        sky_box: tuple[SkyCoord, SkyCoord] | None = None,
         map_units: u.Unit | None = None,
         rerun: bool = False,
         rerun_pointing_model: bool = False,
@@ -89,7 +89,7 @@ class MapCatDatabaseReader(ABC):
         self.array = array
         self.instrument = instrument
         self.map_units = map_units if map_units is not None else self.default_map_units
-        self.box = box
+        self.sky_box = sky_box
         self.rerun = rerun
         self.rerun_pointing_model = rerun_pointing_model
         self._map_list = None
@@ -218,7 +218,7 @@ class IntensityMapReader(MapCatDatabaseReader):
             time_filename=mapcat_settings.depth_one_parent / result.mean_time_path,
             start_time=datetime.fromtimestamp(result.start_time, tz=timezone.utc),
             end_time=datetime.fromtimestamp(result.stop_time, tz=timezone.utc),
-            box=self.box,
+            sky_box=self.sky_box,
             intensity_units=self.map_units,
             frequency=result.frequency,
             array=result.tube_slot,
@@ -240,7 +240,7 @@ class RhoKappaMapReader(MapCatDatabaseReader):
             time_filename=mapcat_settings.depth_one_parent / result.mean_time_path,
             start_time=datetime.fromtimestamp(result.start_time, tz=timezone.utc),
             end_time=datetime.fromtimestamp(result.stop_time, tz=timezone.utc),
-            box=self.box,
+            sky_box=self.sky_box,
             flux_units=self.map_units,
             frequency=result.frequency,
             array=result.tube_slot,
@@ -262,7 +262,7 @@ class FluxMapReader(MapCatDatabaseReader):
             time_filename=mapcat_settings.depth_one_parent / result.mean_time_path,
             start_time=datetime.fromtimestamp(result.start_time, tz=timezone.utc),
             end_time=datetime.fromtimestamp(result.stop_time, tz=timezone.utc),
-            box=self.box,
+            sky_box=self.sky_box,
             flux_units=self.map_units,
             frequency=result.frequency,
             array=result.tube_slot,

--- a/sotrplib/maps/postprocessor.py
+++ b/sotrplib/maps/postprocessor.py
@@ -5,7 +5,6 @@ the snr and flux arrays already exist.
 """
 
 from abc import ABC, abstractmethod
-from math import pi
 from pathlib import Path
 
 import structlog
@@ -44,28 +43,11 @@ class GalaxyMask(MapPostprocessor):
         self.log = log or structlog.get_logger()
 
     def postprocess(self, input_map: ProcessableMap) -> ProcessableMap:
-        enmap_box = (
-            [
-                [
-                    input_map.box[0].dec.to_value(u.rad),
-                    input_map.box[0].ra.to_value(u.rad),
-                ],
-                [
-                    input_map.box[1].dec.to_value(u.rad),
-                    input_map.box[1].ra.to_value(u.rad),
-                ],
-            ]
-            if input_map.box is not None
-            else None
-        )
-        if enmap_box is not None:
-            if enmap_box[0][1] < enmap_box[1][1]:
-                enmap_box[1][1] -= 2 * pi
         galaxy_mask = mask_dustgal(
             imap=input_map.flux,
             galmask=enmap.read_map(
                 fname=str(self.mask_path),
-                box=enmap_box,
+                box=input_map.bbox,
             ),
         )
         if self.invert:

--- a/sotrplib/maps/utils.py
+++ b/sotrplib/maps/utils.py
@@ -1,16 +1,25 @@
+from typing import TypeAlias
+
 import astropy.units as u
 import numpy as np
 from astropy.coordinates import SkyCoord
 from pixell import enmap
 
+Box: TypeAlias = (
+    np.ndarray
+)  # shape (2,2): [[dec_min, ra_max],[dec_max, ra_min]] in radians
 
-def skycoord_box_to_enmap_box(sky_box: tuple[SkyCoord, SkyCoord]) -> list:
+
+def skycoord_box_to_enmap_box(sky_box: tuple[SkyCoord, SkyCoord]) -> Box:
     """Convert a ``(lower_left, upper_right)`` SkyCoord box to a pixell enmap box.
-
+    Convert to ICRS frame to use internally.
     ``sky_box[0]`` must be ``SkyCoord(ra=ra_min, dec=dec_min)`` and ``sky_box[1]``
     must be ``SkyCoord(ra=ra_max, dec=dec_max)``.  Wrap is inferred when
     ``sky_box[0].ra > sky_box[1].ra``.
+    returned pixell box has the form ``[[dec_min, ra_max], [dec_max, ra_min]]`` in radians.
     """
+    # make sure the input is in ICRS frame for internal use
+    sky_box = (s.to_icrs() for s in sky_box)
     ra_min = sky_box[0].ra.to_value(u.rad)
     ra_max = sky_box[1].ra.to_value(u.rad)
     dec_min = sky_box[0].dec.to_value(u.rad)
@@ -20,19 +29,26 @@ def skycoord_box_to_enmap_box(sky_box: tuple[SkyCoord, SkyCoord]) -> list:
     return [[dec_min, ra_max], [dec_max, ra_min]]
 
 
-def enmap_box_to_skycoord(raw_box) -> tuple[SkyCoord, SkyCoord]:
-    """Convert a pixell enmap box to a ``(lower_left, upper_right)`` SkyCoord tuple.
+def enmap_box_to_skycoord(raw_box: Box) -> tuple[SkyCoord, SkyCoord]:
+    """Convert a pixell enmap box to a ``(lower_left, upper_right)`` SkyCoord tuple in icrs frame.
 
     pixell boxes have the form ``[[dec_min, ra_max], [dec_max, ra_min]]`` where
-    ``ra_min`` may be negative for wrapping regions.  The returned tuple follows
+    ``ra_min`` may be negative for wrapping regions.
+    Expected input is in radians.
+
+    The returned tuple follows
     the ``ProcessableMap.sky_box`` convention:
     ``(SkyCoord(ra=ra_min, dec=dec_min), SkyCoord(ra=ra_max, dec=dec_max))``.
     For a wrapping region ``raw_box[1][1]`` is negative and SkyCoord normalises
     it to near 2π, so ``sky_box[0].ra > sky_box[1].ra`` signals the wrap.
     """
     return (
-        SkyCoord(raw_box[1][1] * u.rad, raw_box[0][0] * u.rad),  # (ra_min, dec_min)
-        SkyCoord(raw_box[0][1] * u.rad, raw_box[1][0] * u.rad),  # (ra_max, dec_max)
+        SkyCoord(
+            raw_box[1][1] * u.rad, raw_box[0][0] * u.rad, frame="icrs"
+        ),  # (ra_min, dec_min)
+        SkyCoord(
+            raw_box[0][1] * u.rad, raw_box[1][0] * u.rad, frame="icrs"
+        ),  # (ra_max, dec_max)
     )
 
 

--- a/sotrplib/maps/utils.py
+++ b/sotrplib/maps/utils.py
@@ -1,13 +1,13 @@
-from typing import TypeAlias
+from typing import Literal
 
 import astropy.units as u
 import numpy as np
 from astropy.coordinates import SkyCoord
 from pixell import enmap
 
-Box: TypeAlias = (
-    np.ndarray
-)  # shape (2,2): [[dec_min, ra_max],[dec_max, ra_min]] in radians
+type Box = np.ndarray[
+    tuple[Literal[2], Literal[2]], np.dtype[np.float64]
+]  # shape (2,2): [[dec_min, ra_max],[dec_max, ra_min]] in radians
 
 
 def skycoord_box_to_enmap_box(sky_box: tuple[SkyCoord, SkyCoord]) -> Box:

--- a/sotrplib/maps/utils.py
+++ b/sotrplib/maps/utils.py
@@ -1,4 +1,39 @@
+import astropy.units as u
+import numpy as np
+from astropy.coordinates import SkyCoord
 from pixell import enmap
+
+
+def skycoord_box_to_enmap_box(sky_box: tuple[SkyCoord, SkyCoord]) -> list:
+    """Convert a ``(lower_left, upper_right)`` SkyCoord box to a pixell enmap box.
+
+    ``sky_box[0]`` must be ``SkyCoord(ra=ra_min, dec=dec_min)`` and ``sky_box[1]``
+    must be ``SkyCoord(ra=ra_max, dec=dec_max)``.  Wrap is inferred when
+    ``sky_box[0].ra > sky_box[1].ra``.
+    """
+    ra_min = sky_box[0].ra.to_value(u.rad)
+    ra_max = sky_box[1].ra.to_value(u.rad)
+    dec_min = sky_box[0].dec.to_value(u.rad)
+    dec_max = sky_box[1].dec.to_value(u.rad)
+    if ra_min > ra_max:
+        return [[dec_min, ra_max], [dec_max, ra_min - 2 * np.pi]]
+    return [[dec_min, ra_max], [dec_max, ra_min]]
+
+
+def enmap_box_to_skycoord(raw_box) -> tuple[SkyCoord, SkyCoord]:
+    """Convert a pixell enmap box to a ``(lower_left, upper_right)`` SkyCoord tuple.
+
+    pixell boxes have the form ``[[dec_min, ra_max], [dec_max, ra_min]]`` where
+    ``ra_min`` may be negative for wrapping regions.  The returned tuple follows
+    the ``ProcessableMap.sky_box`` convention:
+    ``(SkyCoord(ra=ra_min, dec=dec_min), SkyCoord(ra=ra_max, dec=dec_max))``.
+    For a wrapping region ``raw_box[1][1]`` is negative and SkyCoord normalises
+    it to near 2π, so ``sky_box[0].ra > sky_box[1].ra`` signals the wrap.
+    """
+    return (
+        SkyCoord(raw_box[1][1] * u.rad, raw_box[0][0] * u.rad),  # (ra_min, dec_min)
+        SkyCoord(raw_box[0][1] * u.rad, raw_box[1][0] * u.rad),  # (ra_max, dec_max)
+    )
 
 
 def pixell_map_union(map1, map2, op=lambda a, b: a + b):

--- a/sotrplib/sims/maps.py
+++ b/sotrplib/sims/maps.py
@@ -11,6 +11,7 @@ from pydantic import AwareDatetime, BaseModel
 from structlog.types import FilteringBoundLogger
 
 from sotrplib.maps.core import ProcessableMap
+from sotrplib.maps.utils import skycoord_box_to_enmap_box
 from sotrplib.sims import sim_maps
 
 
@@ -38,7 +39,7 @@ class SimulatedMap(ProcessableMap):
         array: str | None = None,
         instrument: str | None = None,
         simulation_parameters: SimulationParameters | None = None,
-        box: tuple[SkyCoord, SkyCoord] | None = None,
+        sky_box: tuple[SkyCoord, SkyCoord] | None = None,
         include_half_pixel_offset: bool = False,
         log: FilteringBoundLogger | None = None,
     ):
@@ -64,7 +65,7 @@ class SimulatedMap(ProcessableMap):
         """
         self.observation_start = observation_start
         self.observation_end = observation_end
-        self.box = box
+        self.sky_box = sky_box
         self.include_half_pixel_offset = include_half_pixel_offset
         self.frequency = frequency or "f090"
         self.array = array or "pa5"
@@ -76,24 +77,24 @@ class SimulatedMap(ProcessableMap):
         self.log = log or structlog.get_logger()
 
     @property
-    def bbox(self) -> tuple[SkyCoord, SkyCoord]:
-        if self.box is not None:
-            return self.box
-        self.box = (
-            SkyCoord(
-                ra=self.simulation_parameters.center_ra
-                - self.simulation_parameters.width_ra,
-                dec=self.simulation_parameters.center_dec
-                - self.simulation_parameters.width_dec,
-            ),
-            SkyCoord(
-                ra=self.simulation_parameters.center_ra
-                + self.simulation_parameters.width_ra,
-                dec=self.simulation_parameters.center_dec
-                + self.simulation_parameters.width_dec,
-            ),
-        )
-        return self.box
+    def bbox(self) -> np.ndarray:
+        if (flux := getattr(self, "flux", None)) is not None:
+            return enmap.box(flux.shape, flux.wcs)
+        if self.sky_box is not None:
+            return skycoord_box_to_enmap_box(self.sky_box)
+        ra_min = (
+            self.simulation_parameters.center_ra - self.simulation_parameters.width_ra
+        ).to_value(u.rad)
+        ra_max = (
+            self.simulation_parameters.center_ra + self.simulation_parameters.width_ra
+        ).to_value(u.rad)
+        dec_min = (
+            self.simulation_parameters.center_dec - self.simulation_parameters.width_dec
+        ).to_value(u.rad)
+        dec_max = (
+            self.simulation_parameters.center_dec + self.simulation_parameters.width_dec
+        ).to_value(u.rad)
+        return np.array([[dec_min, ra_max], [dec_max, ra_min]])
 
     def build(self):
         log = self.log.bind(parameters=self.simulation_parameters)
@@ -233,15 +234,11 @@ class SimulatedMapFromGeometry(ProcessableMap):
         self.log = log or structlog.get_logger()
 
     @property
-    def bbox(self) -> tuple[SkyCoord, SkyCoord]:
-        if self.box is not None:
-            return self.box
+    def bbox(self) -> np.ndarray:
+        if (flux := getattr(self, "flux", None)) is not None:
+            return enmap.box(flux.shape, flux.wcs)
         shape, wcs = enmap.read_map_geometry(str(self.geometry_source_map))
-        self.box = (
-            wcs.array_index_to_world(0, 0),
-            wcs.array_index_to_world(shape[-2], shape[-1]),
-        )
-        return self.box
+        return enmap.box(shape, wcs)
 
     def build(self):
         log = self.log.bind(geometry_source_map=self.geometry_source_map)

--- a/sotrplib/sims/sim_source_generators.py
+++ b/sotrplib/sims/sim_source_generators.py
@@ -55,12 +55,12 @@ class SimulatedSourceGenerator(ABC):
     def generate(
         self,
         input_map: ProcessableMap | None = None,
-        box: tuple[SkyCoord] | None = None,
+        sky_box: tuple[SkyCoord, SkyCoord] | None = None,
         time_range: tuple[AwareDatetime | None, AwareDatetime | None] | None = None,
     ) -> tuple[list[SimulatedSource], SourceCatalog]:
         """
-        Generate the simulated sources, optionally within a map or a box on the sky.
-        If input_map is provided, box is to be ignored and inject only within the map area.
+        Generate the simulated sources, optionally within a map or a sky_box on the sky.
+        If input_map is provided, sky_box is to be ignored and inject only within the map area.
         If time_range is provided, it specifies the time range for the simulation.
         Returns both the list of the core 'sources' for use in the source
         simulator, as well as a source catlaog that contains at least some of
@@ -91,11 +91,11 @@ class FixedSourceGenerator(SimulatedSourceGenerator):
     def generate(
         self,
         input_map: ProcessableMap | None = None,
-        box: tuple[SkyCoord] | None = None,
+        sky_box: tuple[SkyCoord, SkyCoord] | None = None,
         time_range: tuple[AwareDatetime | None, AwareDatetime | None] | None = None,
     ):
-        if box is None and input_map is None:
-            box = [
+        if sky_box is None and input_map is None:
+            sky_box = [
                 SkyCoord(ra=0.0 * u.deg, dec=-89.99 * u.deg),
                 SkyCoord(ra=359.99 * u.deg, dec=89.99 * u.deg),
             ]
@@ -103,13 +103,16 @@ class FixedSourceGenerator(SimulatedSourceGenerator):
         if input_map is not None:
             positions = generate_random_positions_in_map(self.number, input_map.flux)
         else:
+            # sky_box[0] = (ra_min, dec_min), sky_box[1] = (ra_max, dec_max).
+            # When the box wraps RA=0, sky_box[0].ra > sky_box[1].ra (e.g. 357° vs 3°);
+            # generate_random_positions handles that by converting to negative RA.
             positions = generate_random_positions(
                 self.number,
-                ra_lims=(box[0].ra, box[1].ra),
-                dec_lims=(box[0].dec, box[1].dec),
+                ra_lims=(sky_box[0].ra, sky_box[1].ra),
+                dec_lims=(sky_box[0].dec, sky_box[1].dec),
             )
 
-        log = self.log.bind(box=box)
+        log = self.log.bind(sky_box=sky_box)
 
         # Potential issue with this setup is that you've got overlapping sources..?
         # But that's something we should probably handle anyway...
@@ -189,11 +192,11 @@ class GaussianTransientSourceGenerator(SimulatedSourceGenerator):
     def generate(
         self,
         input_map: ProcessableMap | None = None,
-        box: tuple[SkyCoord] | None = None,
+        sky_box: tuple[SkyCoord, SkyCoord] | None = None,
         time_range: tuple[AwareDatetime | None, AwareDatetime | None] | None = None,
     ):
-        if box is None and input_map is None:
-            box = [
+        if sky_box is None and input_map is None:
+            sky_box = [
                 SkyCoord(ra=0.0 * u.deg, dec=-89.99 * u.deg),
                 SkyCoord(ra=359.99 * u.deg, dec=89.99 * u.deg),
             ]
@@ -230,7 +233,7 @@ class GaussianTransientSourceGenerator(SimulatedSourceGenerator):
 
         log = self.log.bind(
             n=self.number,
-            box=box,
+            sky_box=sky_box,
             time_range=[self.flare_earliest_time, self.flare_latest_time],
         )
 
@@ -255,10 +258,13 @@ class GaussianTransientSourceGenerator(SimulatedSourceGenerator):
         if input_map is not None:
             positions = generate_random_positions_in_map(self.number, input_map.flux)
         else:
+            # sky_box[0] = (ra_min, dec_min), sky_box[1] = (ra_max, dec_max).
+            # When the box wraps RA=0, sky_box[0].ra > sky_box[1].ra (e.g. 357° vs 3°);
+            # generate_random_positions handles that by converting to negative RA.
             positions = generate_random_positions(
                 self.number,
-                ra_lims=(box[0].ra, box[1].ra),
-                dec_lims=(box[0].dec, box[1].dec),
+                ra_lims=(sky_box[0].ra, sky_box[1].ra),
+                dec_lims=(sky_box[0].dec, sky_box[1].dec),
             )
 
         sources = [
@@ -370,7 +376,8 @@ class SOCatSourceGenerator(SimulatedSourceGenerator):
 
     def generate(
         self,
-        box: tuple[SkyCoord] | None = None,
+        input_map: ProcessableMap | None = None,
+        sky_box: tuple[SkyCoord, SkyCoord] | None = None,
         time_range: tuple[AwareDatetime | None, AwareDatetime | None] | None = None,
     ):
         self.log = self.log.bind(
@@ -379,13 +386,15 @@ class SOCatSourceGenerator(SimulatedSourceGenerator):
         socat_client_settings = SOCatClientSettings()
         socat_client = socat_client_settings.client
 
-        if box is None:
-            box = [
+        if sky_box is None:
+            sky_box = [
                 SkyCoord(ra=0.0 * u.deg, dec=-89.99 * u.deg),
                 SkyCoord(ra=359.99 * u.deg, dec=89.99 * u.deg),
             ]
 
-        sources = socat_client.get_box_fixed(lower_left=box[0], upper_right=box[1])
+        sources = socat_client.get_box_fixed(
+            lower_left=sky_box[0], upper_right=sky_box[1]
+        )
         random.shuffle(sources)
 
         number_of_sources = len(sources)
@@ -397,7 +406,7 @@ class SOCatSourceGenerator(SimulatedSourceGenerator):
             n_sources=number_of_sources,
             n_fixed=number_of_fixed,
             n_flares=number_of_flares,
-            box=box,
+            sky_box=sky_box,
         )
         all_sources = [
             RegisteredSource(

--- a/sotrplib/sims/sources/core.py
+++ b/sotrplib/sims/sources/core.py
@@ -54,9 +54,13 @@ class ProcessableMapWithSimulatedSources(ProcessableMap):
         self.array = original_map.array
         self.finalized = original_map.finalized
         self.map_resolution = original_map.map_resolution
-        self.box = original_map.box
+        self.sky_box = original_map.sky_box
 
         return
+
+    @property
+    def bbox(self) -> np.ndarray:
+        return enmap.box(self.flux.shape, self.flux.wcs)
 
     def build(self):
         return

--- a/sotrplib/sources/sources.py
+++ b/sotrplib/sources/sources.py
@@ -2,6 +2,7 @@ from typing import Literal, Optional
 
 import numpy as np
 import structlog
+import uuid7 as uuid
 from astropy import units as u
 from astropydantic import AstroPydanticQuantity, AstroPydanticTime, AstroPydanticUnit
 from numpydantic import NDArray
@@ -31,7 +32,7 @@ class CrossMatch(BaseModel):
     err_flux: AstroPydanticQuantity[u.mJy] | None = None
     frequency: AstroPydanticQuantity[u.GHz] | None = None
     catalog_name: str | None = None
-    catalog_idx: int | None = None
+    catalog_idx: int | str | uuid.UUID | None = None
     alternate_names: list[str] | None = None
 
 

--- a/tests/test_forced_photometry/conftest.py
+++ b/tests/test_forced_photometry/conftest.py
@@ -134,7 +134,7 @@ def mapset_with_sources():
             observation_end=end_obs,
             frequency="f090",
             array="pa5",
-            box=[SkyCoord(ra=left, dec=bottom), SkyCoord(ra=right, dec=top)],
+            sky_box=[SkyCoord(ra=left, dec=bottom), SkyCoord(ra=right, dec=top)],
         )
 
         base_map.build()

--- a/tests/test_forced_photometry/conftest.py
+++ b/tests/test_forced_photometry/conftest.py
@@ -123,7 +123,7 @@ def mapset_with_sources():
     )
 
     sources, _ = generator.generate(
-        box=[SkyCoord(ra=left, dec=bottom), SkyCoord(ra=right, dec=top)]
+        sky_box=[SkyCoord(ra=left, dec=bottom), SkyCoord(ra=right, dec=top)]
     )
     ret_maps = []
     for i in range(10):

--- a/tests/test_maps/conftest.py
+++ b/tests/test_maps/conftest.py
@@ -90,30 +90,21 @@ def overlapping_source_params():
 
 
 def build_wcs(map_params, mapkey):
-    nx, ny = (
-        int(map_params[mapkey]["width_ra"] / map_params[mapkey]["resolution"]),
-        int(map_params[mapkey]["width_dec"] / map_params[mapkey]["resolution"]),
-    )
-    nshape = (ny, nx)
-    wcs = enmap.wcsutils.car(
-        pos=[
-            [
-                map_params[mapkey]["center_ra"].to(u.deg).value
-                - 0.5 * map_params[mapkey]["width_ra"].to(u.deg).value,
-                map_params[mapkey]["center_dec"].to(u.deg).value
-                - 0.5 * map_params[mapkey]["width_dec"].to(u.deg).value,
-            ],
-            [
-                map_params[mapkey]["center_ra"].to(u.deg).value
-                + 0.5 * map_params[mapkey]["width_ra"].to(u.deg).value,
-                map_params[mapkey]["center_dec"].to(u.deg).value
-                + 0.5 * map_params[mapkey]["width_dec"].to(u.deg).value,
-            ],
-        ],
-        shape=nshape,
-        res=map_params[mapkey]["resolution"].to(u.deg).value,
-    )
-    return nshape, wcs
+    res = map_params[mapkey]["resolution"].to_value(u.rad)
+    ra_min = (
+        map_params[mapkey]["center_ra"] - 0.5 * map_params[mapkey]["width_ra"]
+    ).to_value(u.rad)
+    ra_max = (
+        map_params[mapkey]["center_ra"] + 0.5 * map_params[mapkey]["width_ra"]
+    ).to_value(u.rad)
+    dec_min = (
+        map_params[mapkey]["center_dec"] - 0.5 * map_params[mapkey]["width_dec"]
+    ).to_value(u.rad)
+    dec_max = (
+        map_params[mapkey]["center_dec"] + 0.5 * map_params[mapkey]["width_dec"]
+    ).to_value(u.rad)
+    box = np.array([[dec_min, ra_max], [dec_max, ra_min]])
+    return enmap.geometry(box, res=res)
 
 
 def create_map(

--- a/tests/test_maps/test_coadding.py
+++ b/tests/test_maps/test_coadding.py
@@ -55,20 +55,14 @@ def test_rhokappa_coadder_separate(separate_map_set_1, separate_map_set_2):
     assert coadd.flux is not None
     assert coadd.snr is not None
     assert coadd.time_mean is not None
-    corners = coadd.bbox
-    assert corners[0].ra.to_value(u.deg) == pytest.approx(
-        min(input_maps[0].bbox[0].ra, input_maps[1].bbox[0].ra).to_value(u.deg)
-    )
-    assert corners[0].dec.to_value(u.deg) == pytest.approx(
-        min(input_maps[0].bbox[0].dec, input_maps[1].bbox[0].dec).to_value(u.deg)
-    )
-
-    assert corners[1].ra.to_value(u.deg) == pytest.approx(
-        max(input_maps[0].bbox[1].ra, input_maps[1].bbox[1].ra).to_value(u.deg)
-    )
-    assert corners[1].dec.to_value(u.deg) == pytest.approx(
-        max(input_maps[0].bbox[1].dec, input_maps[1].bbox[1].dec).to_value(u.deg)
-    )
+    corners = (
+        coadd.bbox
+    )  # [[dec_min, ra_max], [dec_max, ra_min]] in radians (pixell east-left)
+    b0, b1 = input_maps[0].bbox, input_maps[1].bbox
+    assert corners[0][0] == pytest.approx(min(b0[0][0], b1[0][0]))  # dec_min
+    assert corners[0][1] == pytest.approx(max(b0[0][1], b1[0][1]))  # ra_max (east edge)
+    assert corners[1][0] == pytest.approx(max(b0[1][0], b1[1][0]))  # dec_max
+    assert corners[1][1] == pytest.approx(min(b0[1][1], b1[1][1]))  # ra_min (west edge)
     assert np.all(coadd.hits <= 1)
 
 
@@ -107,20 +101,14 @@ def test_rhokappa_coadder_overlapping(overlapping_map_set_1, overlapping_map_set
     assert coadd.flux is not None
     assert coadd.snr is not None
     assert coadd.time_mean is not None
-    corners = coadd.bbox
-    assert corners[0].ra.to_value(u.deg) == pytest.approx(
-        min(input_maps[0].bbox[0].ra, input_maps[1].bbox[0].ra).to_value(u.deg)
-    )
-    assert corners[0].dec.to_value(u.deg) == pytest.approx(
-        min(input_maps[0].bbox[0].dec, input_maps[1].bbox[0].dec).to_value(u.deg)
-    )
-
-    assert corners[1].ra.to_value(u.deg) == pytest.approx(
-        max(input_maps[0].bbox[1].ra, input_maps[1].bbox[1].ra).to_value(u.deg)
-    )
-    assert corners[1].dec.to_value(u.deg) == pytest.approx(
-        max(input_maps[0].bbox[1].dec, input_maps[1].bbox[1].dec).to_value(u.deg)
-    )
+    corners = (
+        coadd.bbox
+    )  # [[dec_min, ra_max], [dec_max, ra_min]] in radians (pixell east-left)
+    b0, b1 = input_maps[0].bbox, input_maps[1].bbox
+    assert corners[0][0] == pytest.approx(min(b0[0][0], b1[0][0]))  # dec_min
+    assert corners[0][1] == pytest.approx(max(b0[0][1], b1[0][1]))  # ra_max (east edge)
+    assert corners[1][0] == pytest.approx(max(b0[1][0], b1[1][0]))  # dec_max
+    assert corners[1][1] == pytest.approx(min(b0[1][1], b1[1][1]))  # ra_min (west edge)
     assert ~np.all(coadd.hits <= 1)
 
 
@@ -196,14 +184,16 @@ def test_coadding_with_sources_in_separate_maps(
             separate_source_params["source2"]["ra"].to_value(u.rad),
         ]
     )
-    assert new_map.flux[int(source_pos_1[0]), int(source_pos_1[1])] == pytest.approx(
+    pix1 = int(source_pos_1[0]), int(source_pos_1[1])
+    pix2 = int(source_pos_2[0]), int(source_pos_2[1])
+    assert new_map.flux[pix1] - float(coadd.flux[pix1]) == pytest.approx(
         separate_source_params["source1"]["flux"].to_value(u.Jy), abs=0.5
     )
-    assert new_map.flux[int(source_pos_2[0]), int(source_pos_2[1])] == pytest.approx(
+    assert new_map.flux[pix2] - float(coadd.flux[pix2]) == pytest.approx(
         separate_source_params["source2"]["flux"].to_value(u.Jy), abs=0.5
     )
-    assert coadd.hits[int(source_pos_1[0]), int(source_pos_1[1])] == 1
-    assert coadd.hits[int(source_pos_2[0]), int(source_pos_2[1])] == 1
+    assert coadd.hits[pix1] == 1
+    assert coadd.hits[pix2] == 1
 
 
 def test_coadding_with_sources_in_overlapping_maps(
@@ -279,11 +269,13 @@ def test_coadding_with_sources_in_overlapping_maps(
             overlapping_source_params["source2"]["ra"].to_value(u.rad),
         ]
     )
-    assert new_map.flux[int(source_pos_1[0]), int(source_pos_1[1])] == pytest.approx(
+    pix1 = int(source_pos_1[0]), int(source_pos_1[1])
+    pix2 = int(source_pos_2[0]), int(source_pos_2[1])
+    assert new_map.flux[pix1] - float(coadd.flux[pix1]) == pytest.approx(
         overlapping_source_params["source1"]["flux"].to_value(u.Jy), abs=0.5
     )
-    assert new_map.flux[int(source_pos_2[0]), int(source_pos_2[1])] == pytest.approx(
+    assert new_map.flux[pix2] - float(coadd.flux[pix2]) == pytest.approx(
         overlapping_source_params["source2"]["flux"].to_value(u.Jy), abs=0.5
     )
-    assert coadd.hits[int(source_pos_1[0]), int(source_pos_1[1])] == 2
-    assert coadd.hits[int(source_pos_2[0]), int(source_pos_2[1])] == 1
+    assert coadd.hits[pix1] == 2
+    assert coadd.hits[pix2] == 1

--- a/tests/test_sims/test_sim_source_injection.py
+++ b/tests/test_sims/test_sim_source_injection.py
@@ -66,7 +66,7 @@ def test_fixed_source_generation():
     )
 
     sources, cat = generator.generate(
-        box=[SkyCoord(ra=left, dec=bottom), SkyCoord(ra=right, dec=top)]
+        sky_box=[SkyCoord(ra=left, dec=bottom), SkyCoord(ra=right, dec=top)]
     )
 
     assert len(sources) == number
@@ -105,7 +105,7 @@ def test_gaussian_source_generation():
     )
 
     sources, cat = generator.generate(
-        box=[SkyCoord(ra=left, dec=bottom), SkyCoord(ra=right, dec=top)]
+        sky_box=[SkyCoord(ra=left, dec=bottom), SkyCoord(ra=right, dec=top)]
     )
 
     assert len(sources) == number
@@ -181,7 +181,7 @@ def test_source_injection_forced_photometry():
     )
 
     sources, cat = generator.generate(
-        box=[SkyCoord(ra=left, dec=bottom), SkyCoord(ra=right, dec=top)]
+        sky_box=[SkyCoord(ra=left, dec=bottom), SkyCoord(ra=right, dec=top)]
     )
     start_obs = start_time
     end_obs = start_time + datetime.timedelta(hours=2)
@@ -237,7 +237,7 @@ def test_source_injection_blind_search():
     )
 
     sources, cat = generator.generate(
-        box=[SkyCoord(ra=left, dec=bottom), SkyCoord(ra=right, dec=top)]
+        sky_box=[SkyCoord(ra=left, dec=bottom), SkyCoord(ra=right, dec=top)]
     )
     start_obs = start_time
     end_obs = start_time + datetime.timedelta(hours=2)
@@ -298,7 +298,7 @@ def test_source_injection_blind_search_SAT():
     )
 
     sources, cat = generator.generate(
-        box=[SkyCoord(ra=left, dec=bottom), SkyCoord(ra=right, dec=top)]
+        sky_box=[SkyCoord(ra=left, dec=bottom), SkyCoord(ra=right, dec=top)]
     )
 
     start_obs = start_time

--- a/tests/test_sims/test_sim_source_injection.py
+++ b/tests/test_sims/test_sim_source_injection.py
@@ -190,7 +190,7 @@ def test_source_injection_forced_photometry():
         observation_end=end_obs,
         frequency="f090",
         array="pa5",
-        box=[SkyCoord(ra=left, dec=bottom), SkyCoord(ra=right, dec=top)],
+        sky_box=[SkyCoord(ra=left, dec=bottom), SkyCoord(ra=right, dec=top)],
     )
 
     base_map.build()
@@ -246,7 +246,7 @@ def test_source_injection_blind_search():
         observation_end=end_obs,
         frequency="f090",
         array="pa5",
-        box=[SkyCoord(ra=left, dec=bottom), SkyCoord(ra=right, dec=top)],
+        sky_box=[SkyCoord(ra=left, dec=bottom), SkyCoord(ra=right, dec=top)],
     )
 
     base_map.build()
@@ -310,7 +310,7 @@ def test_source_injection_blind_search_SAT():
         array=None,
         instrument="SOSAT",
         simulation_parameters=map_sim_params,
-        box=[SkyCoord(ra=left, dec=bottom), SkyCoord(ra=right, dec=top)],
+        sky_box=[SkyCoord(ra=left, dec=bottom), SkyCoord(ra=right, dec=top)],
     )
 
     base_map.build()


### PR DESCRIPTION
refactor the way the processable map boxes are enacted and used in the library. this is done by refactoring to sky_box which is tuple of SkyCoord and bbox which is the enmap bounding box. SkyCoord can be given to cut boxes but bbox handles the internal box corner usage (i.e. for getting sources in map, etc)

Add some conversion utils to maps/utils (sky_box to enmap_box).

Only use sky_box if user is specifying a box.

Deal with the wrapping around 360 by understanding that ra_min > ra_max means it is wrapped (this solves the SkyCoord 0-360 requirement)