### PR TITLE
BUG: allow pipeline crossmatch to work with non-identical maps

### DIFF
--- a/sotrplib/handlers/base.py
+++ b/sotrplib/handlers/base.py
@@ -280,18 +280,14 @@ class BaseRunner:
     def crossmatch_pair(
         self, candidates: tuple[list], radius: float = 1.5
     ) -> list[list[tuple]]:
-        positions = np.array(
-            [
-                np.array([[src.dec.value, src.ra.value] for src in sub_candidates])
-                for sub_candidates in candidates
-            ]
-        )
-        if positions.shape[1] == 0:
+        positions_1 = np.array([[src.dec.value, src.ra.value] for src in candidates[0]])
+        positions_2 = np.array([[src.dec.value, src.ra.value] for src in candidates[1]])
+        if len(positions_1) == 0 or len(positions_2) == 0:
             return []
 
         # FIXME: use a better radius
         found, matches = self.profilable_task(crossmatch_mask)(
-            *positions, radius=radius, return_matches=True
+            positions_1, positions_2, radius=radius, return_matches=True
         )
         return matches
 

--- a/tests/test_simulation_pipeline/test_pipeline.py
+++ b/tests/test_simulation_pipeline/test_pipeline.py
@@ -69,6 +69,42 @@ def test_basic_pipeline_lmfit(
     runner.run(maps)
 
 
+def test_basic_pipeline_missing_crossmatches(
+    tmp_path,
+    map_with_sources: tuple[SimulatedMap, list[RegisteredSource]],
+    map_with_single_source: tuple[SimulatedMap, list[RegisteredSource]],
+):
+    """
+    Tests a complete setup of the basic pipeline run with different maps
+    to verify crossmatch.
+    """
+
+    map_1, sources = map_with_sources
+    map_2, _ = map_with_single_source
+    source_cat = RegisteredSourceCatalog(sources=sources)
+    maps = [map_1, map_2]
+
+    runner = PipelineRunner(
+        map_coadder=None,
+        source_catalogs=[],
+        sso_catalogs=[],
+        source_injector=None,
+        preprocessors=None,
+        pointing_provider=None,
+        pointing_residual_model=None,
+        postprocessors=None,
+        source_simulators=None,
+        forced_photometry=TwoDGaussianFitter(mode="lmfit"),
+        source_subtractor=None,
+        blind_search=SigmaClipBlindSearch(),
+        sifter=DefaultSifter(),
+        source_outputs=[PickleSerializer(directory=tmp_path)],
+        map_outputs=None,
+    )
+
+    runner.run(maps)
+
+
 def test_find_single_source_blind(
     map_with_single_source: tuple[SimulatedMap, list[RegisteredSource]],
 ):


### PR DESCRIPTION
This PR fixes the issue @axf295 flagged. I also added a test case that failed with the previous version but now passes.

Closes #163 