### PR TITLE
MAINT: Update catalog_idx type to uuid.UUID

### DIFF
--- a/sotrplib/sources/sources.py
+++ b/sotrplib/sources/sources.py
@@ -2,6 +2,7 @@ from typing import Literal, Optional
 
 import numpy as np
 import structlog
+import uuid7 as uuid
 from astropy import units as u
 from astropydantic import AstroPydanticQuantity, AstroPydanticTime, AstroPydanticUnit
 from numpydantic import NDArray
@@ -31,7 +32,7 @@ class CrossMatch(BaseModel):
     err_flux: AstroPydanticQuantity[u.mJy] | None = None
     frequency: AstroPydanticQuantity[u.GHz] | None = None
     catalog_name: str | None = None
-    catalog_idx: int | None = None
+    catalog_idx: uuid.UUID | None = None
     alternate_names: list[str] | None = None
 
 


### PR DESCRIPTION
Changed catalog_idx type from int to uuid.UUID. This should fix the failing test in e.g., https://github.com/simonsobs/sotrplib/actions/runs/27371889846/job/80886025421.