### PR TITLE
Precalculate source positions in radians

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,6 +1,10 @@
 name: Run tests
 
-on: [push]
+on: 
+  push:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   runtest:

--- a/sotrplib/source_catalog/core.py
+++ b/sotrplib/source_catalog/core.py
@@ -98,6 +98,21 @@ class RegisteredSourceCatalog(SourceCatalog):
     def add_sources(self, sources: list[RegisteredSource]):
         self.sources.extend(sources)
 
+    @property
+    def sources(self):
+        return self._sources
+
+    @sources.setter
+    def sources(self, sources: list[RegisteredSource]):
+        self._sources = sources
+        self._catalog_positions = np.array(
+            [(s.ra.to("radian").value, s.dec.to("radian").value) for s in sources]
+        )
+
+    @property
+    def catalog_positions(self):
+        return self._catalog_positions
+
     def get_sources_in_map(
         self,
         input_map: ProcessableMap,
@@ -202,12 +217,9 @@ class RegisteredSourceCatalog(SourceCatalog):
         if len(self.sources) == 0:
             return []
 
-        catalog_positions = np.array(
-            [(s.ra.to("radian").value, s.dec.to("radian").value) for s in self.sources]
-        )
         matches = pixell_utils.crossmatch(
             pos1=[[ra.to("radian").value, dec.to("radian").value]],
-            pos2=catalog_positions,
+            pos2=self.catalog_positions,
             rmax=radius.to("radian").value,
             mode=method,
             coords="radec",

--- a/sotrplib/source_catalog/core.py
+++ b/sotrplib/source_catalog/core.py
@@ -96,7 +96,10 @@ class RegisteredSourceCatalog(SourceCatalog):
         self.sources = sources
 
     def add_sources(self, sources: list[RegisteredSource]):
-        self.sources.extend(sources)
+        self._sources.extend(sources)
+        self._catalog_positions = np.array(
+            [(s.ra.to("radian").value, s.dec.to("radian").value) for s in self._sources]
+        )
 
     @property
     def sources(self):


### PR DESCRIPTION
I noticed in a profiled run that for large catalogs, the sifter is super slow and almost entirely dominated by converting to radians.
This PR just caches that calculation.