### PR TITLE
update forced-photometry configs / slurm wrapper

### DIFF
--- a/sample_read_mapcat.json
+++ b/sample_read_mapcat.json
@@ -21,7 +21,7 @@
         "near_source_rel_flux_limit": 0.3
     },
     "pointing_residual": {
-        "pointing_residual_type": "polynomial",
+        "pointing_residual_type": "mean",
         "min_snr": 5.0,
         "min_sources": 5,
         "sigma_clip_level": 3.0,

--- a/scripts/historical_lightcurve_extractor/slurm_wrapper_mapcat_historical_extractor.py
+++ b/scripts/historical_lightcurve_extractor/slurm_wrapper_mapcat_historical_extractor.py
@@ -34,6 +34,7 @@ P.add_argument(
     action="store",
     default=[],
     nargs="+",
+    required=True,
     help="Source ids of sources to extract.",
 )
 
@@ -43,6 +44,16 @@ P.add_argument(
     default="10 mJy",
     type=str,
     help="Flux threshold for source extraction, json compatible quantity.",
+)
+
+P.add_argument(
+    "--socat-db-path",
+    action="store",
+    default="",
+    help="Path to a sqlite socat database. The sources given via --ra/--dec/--flux/"
+    "--source-id are added to this database (creating it if needed) so the slurm "
+    "jobs can look them up as monitored sources. If empty, defaults to "
+    "'tmp_socat.db' inside --out-dir.",
 )
 
 P.add_argument(
@@ -145,7 +156,9 @@ P.add_argument(
 args = P.parse_args()
 
 
-def generate_slurm_header(jobname, groupname, cpu_per_task, script_dir, slurm_out_dir):
+def generate_slurm_header(
+    jobname, groupname, cpu_per_task, script_dir, slurm_out_dir, socat_db_path
+):
     slurm_header = f"""#!/bin/bash
 #SBATCH --job-name={jobname}            # create a short name for your job
 #SBATCH -A {groupname}                    # group name, by default simonsobs
@@ -156,22 +169,17 @@ def generate_slurm_header(jobname, groupname, cpu_per_task, script_dir, slurm_ou
 #SBATCH --time=04:59:00          # total run time limit (HH:MM:SS)
 #SBATCH --output={slurm_out_dir}%x.out
 
-module load soconda/3.11/v0.6.3
-
 export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
-cd {script_dir}
 
+cd {script_dir}
 source .venv/bin/activate
 
-export socat_client_client_type=pickle
-export socat_client_pickle_path=catmaker_090_3pass_socat.pickle
+export socat_client_client_type=db
+export socat_model_database_name={socat_db_path}
 
 export MAPCAT_DEPTH_ONE_PARENT=/scratch/gpfs/SIMONSOBS/users/amfoster/so/lat_early_maps/
 export MAPCAT_DATABASE_NAME=/scratch/gpfs/SIMONSOBS/users/amfoster/so/lat_early_maps/out_deep56/mapcat.sqlite
 
-if [ ! -e "socat.pickle" ]; then
-    socat-act-fits -f /scratch/gpfs/SIMONSOBS/users/amfoster/depth1_act_maps/inputs/catmaker_090_3pass_clean.fits  -o catmaker_090_3pass_socat.pickle
-fi
 
 """
     return slurm_header
@@ -186,8 +194,6 @@ def generate_config_json(
     box_size: float = 0.5,
     source_ra: float | None = None,
     source_dec: float | None = None,
-    source_flux: float | None = None,
-    source_id: str | None = None,
 ):
     config_text = f"""{{
     "maps": {{
@@ -210,23 +216,7 @@ def generate_config_json(
     }},
     "source_catalogs": [
         {{
-            "catalog_type": "socat",
-            "flux_lower_limit": "{flux_low_limit}",
-            "additional_positions":
-            [
-                    {{
-                    "ra":{{"value":{source_ra},"unit":"deg"}},
-                    "dec":{{"value":{source_dec},"unit":"deg"}}
-                    }}
-            ],
-            "additional_fluxes":["{source_flux} Jy"],
-            "additional_source_ids":["{source_id}"]
-        }}
-    ],
-    "sso_catalogs": [
-        {{
-            "catalog_type": "sso",
-            "db_path": "./sotrplib/solar_system/mpc_orbital_params_bright_asteroids.csv"
+            "catalog_type": "socat"
         }}
     ],
     "preprocessors": [
@@ -259,14 +249,8 @@ def generate_config_json(
             "tile_size": "0.5 deg"
         }}
     ],
-    "source_subtractor": {{
-            "subtractor_type": "photutils"
-    }},
-    "blind_search": {{
-            "search_type": "photutils"
-    }},
     "forced_photometry": {{
-        "photometry_type": "scipy",
+        "photometry_type": "lmfit",
         "reproject_thumbnails": "True",
         "flux_limit_centroid": "0.1 Jy",
         "thumbnail_half_width": "{thumbnail_half_width}",
@@ -277,7 +261,7 @@ def generate_config_json(
         "sifter_type": "default",
         "min_match_radius": "5.0 arcmin"
     }},
-    "outputs": [
+    "source_outputs": [
         {{
             "output_type": "pickle",
             "directory": "{output_dir}"
@@ -317,6 +301,32 @@ if not os.path.exists(args.out_dir):
 if not os.path.exists(args.slurm_script_dir):
     os.mkdir(args.slurm_script_dir)
 
+if not args.socat_db_path:
+    args.socat_db_path = os.path.join(args.out_dir, "tmp_socat.db")
+args.socat_db_path = os.path.abspath(args.socat_db_path)
+
+## Build a temporary socat sqlite database and register the requested
+## sources in it as monitored sources, so the slurm jobs can look them up.
+if args.source_id:
+    os.environ["socat_client_client_type"] = "db"
+    os.environ["socat_model_database_name"] = args.socat_db_path
+
+    from astropy import units as u
+    from astropy.coordinates import ICRS
+    from socat.client.settings import SOCatClientSettings
+
+    socat_client = SOCatClientSettings().client
+    for s, source_id in enumerate(args.source_id):
+        socat_client.create_source(
+            position=ICRS(ra=float(args.ra[s]) * u.deg, dec=float(args.dec[s]) * u.deg),
+            flux=float(args.flux[s]) * u.Jy if args.flux else None,
+            name=source_id,
+            flags={"monitored": True},
+        )
+    print(
+        f"Created socat database at {args.socat_db_path} with {len(args.source_id)} source(s)."
+    )
+
 n = 0
 
 
@@ -333,10 +343,6 @@ for band in args.bands:
                         thumbnail_half_width=args.thumbnail_radius,
                         source_ra=float(args.ra[s]),
                         source_dec=float(args.dec[s]),
-                        source_flux=float(args.flux[s])
-                        if args.flux is not None
-                        else 0.1,
-                        source_id=source,
                         box_size=args.box_half_width,
                         output_dir=args.out_dir,
                     )
@@ -347,6 +353,7 @@ for band in args.bands:
                 str(args.ncores),
                 args.script_dir if args.script_dir else os.getcwd(),
                 args.slurm_out_dir,
+                args.socat_db_path,
             )
             slurm_text += f"srun --overlap sotrp -c {config_file} > {args.out_dir}{tube}_{band}_{source}_sotrp.log "
 

--- a/sotrplib/sources/forced_photometry.py
+++ b/sotrplib/sources/forced_photometry.py
@@ -413,16 +413,7 @@ def gaussian_fit(
         ## apply pointing residuals to source position
         source_pos = SkyCoord(ra=source.ra, dec=source.dec)
         if pointing_model is not None:
-            corrected = pointing_model.predict(source_pos)
-            # Workaround for mapcat's PolynomialPointingModel.predict()
-            # returning array-shaped ra/dec even for scalar input (see
-            # https://github.com/simonsobs/mapcat/pull/TODO). Remove once
-            # that fix is merged and pinned.
-            source_pos = SkyCoord(
-                ra=np.atleast_1d(corrected.ra)[0],
-                dec=np.atleast_1d(corrected.dec)[0],
-                frame=corrected.frame,
-            )
+            source_pos = pointing_model.predict(source_pos)
 
         source.ra = source_pos.ra
         source.dec = source_pos.dec

--- a/sotrplib/sources/forced_photometry.py
+++ b/sotrplib/sources/forced_photometry.py
@@ -294,7 +294,7 @@ class LmFitGaussian2DFitter:
         )
 
         amplitude = AstroPydanticQuantity(
-            amplitude + offset, self.source.thumbnail_unit
+            amplitude - offset, self.source.thumbnail_unit
         )
         amplitude_err = (
             AstroPydanticQuantity(
@@ -413,7 +413,16 @@ def gaussian_fit(
         ## apply pointing residuals to source position
         source_pos = SkyCoord(ra=source.ra, dec=source.dec)
         if pointing_model is not None:
-            source_pos = pointing_model.predict(source_pos)
+            corrected = pointing_model.predict(source_pos)
+            # Workaround for mapcat's PolynomialPointingModel.predict()
+            # returning array-shaped ra/dec even for scalar input (see
+            # https://github.com/simonsobs/mapcat/pull/TODO). Remove once
+            # that fix is merged and pinned.
+            source_pos = SkyCoord(
+                ra=np.atleast_1d(corrected.ra)[0],
+                dec=np.atleast_1d(corrected.dec)[0],
+                frame=corrected.frame,
+            )
 
         source.ra = source_pos.ra
         source.dec = source_pos.dec

--- a/sotrplib/sources/forced_photometry.py
+++ b/sotrplib/sources/forced_photometry.py
@@ -294,7 +294,7 @@ class LmFitGaussian2DFitter:
         )
 
         amplitude = AstroPydanticQuantity(
-            amplitude - offset, self.source.thumbnail_unit
+            amplitude + offset, self.source.thumbnail_unit
         )
         amplitude_err = (
             AstroPydanticQuantity(


### PR DESCRIPTION
Update sample configs and the historical lightcurve extractor to lmfit-based photometry, and lets the extractor register monitored sources into a temporary socat db which user can point to via command line args.
