### PR TITLE
Fix LightcurveDBOutput/LightServeOutput for socat's UUID source IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,13 @@ Essentially this is just dictionaries of lists of MeasuredSource objects (and In
 
 These MeasuredSource objects contain information about their measurement and even cutouts.
 
+A `MeasuredSource`/`RegisteredSource` may carry a list of `CrossMatch` objects (see
+`sotrplib/sources/sources.py`) recording catalog matches. When looking up a source by
+identifier (e.g. joining against socat or lightcurvedb), use `CrossMatch.catalog_idx`,
+not `CrossMatch.source_id` -- `catalog_idx` is the catalog's unique, stable identifier
+(e.g. a socat UUID), while `source_id` is sometimes just a human-readable name (e.g.
+"Ceres" for SSO/monitored sources) and is not guaranteed to be unique.
+
 
 ### Running with prefect
 

--- a/sotrplib/outputs/lightcurvedb.py
+++ b/sotrplib/outputs/lightcurvedb.py
@@ -10,6 +10,7 @@ import uuid7
 from astropy.time import Time
 from lightcurvedb.config import Settings as LightcurveDBSettings
 from lightcurvedb.models.cutout import Cutout
+from lightcurvedb.models.exceptions import SourceNotFoundException
 from lightcurvedb.models.flux import FluxMeasurement
 from lightcurvedb.models.source import Source
 from structlog import get_logger
@@ -39,17 +40,49 @@ class LightcurveDBOutput(SourceOutput):
         self.upsert_sources = upsert_sources
         self.log = log or get_logger()
 
-    async def _get_source_translations(self) -> dict[UUID, UUID]:
-        async with self.settings.backend as backend:
-            return {st.socat_id: st.source_id for st in await backend.sources.get_all()}
+    async def _lookup_or_create_source_id(
+        self,
+        backend,
+        socat_id: UUID,
+        name: str,
+        ra: float,
+        dec: float,
+    ) -> UUID | None:
+        """
+        Translate a socat_id to lightcurvedb's own internal source_id via
+        the backend's indexed get_by_socat_id lookup, creating a new
+        lightcurvedb source (with a fresh, unrelated internal source_id)
+        if one doesn't exist yet and upsert_sources is enabled.
+        """
+        try:
+            existing = await backend.sources.get_by_socat_id(socat_id)
+            return existing.source_id
+        except SourceNotFoundException:
+            if not self.upsert_sources:
+                return None
+
+            source_id = await backend.sources.create(
+                source=Source(
+                    socat_id=socat_id,
+                    name=name,
+                    ra=ra,
+                    dec=dec,
+                    variable=False,
+                    extra=None,
+                )
+            )
+
+            await self.log.ainfo(
+                "lightcurvedb.output.upserted_source",
+                socat_id=socat_id,
+                source_id=str(source_id),
+            )
+            return source_id
 
     async def _extract_and_upsert_sources(
         self, forced_photometry_candidates: list[MeasuredSource]
-    ):
-        source_translations = await self._get_source_translations()
-
-        if not self.upsert_sources:
-            return source_translations
+    ) -> dict[UUID, UUID]:
+        source_translations: dict[UUID, UUID] = {}
 
         async with self.settings.backend as backend:
             for source in forced_photometry_candidates:
@@ -63,25 +96,19 @@ class LightcurveDBOutput(SourceOutput):
 
                 socat_id = source.crossmatches[0].catalog_idx
 
-                if socat_id not in source_translations:
-                    source_id = await backend.sources.create(
-                        source=Source(
-                            socat_id=socat_id,
-                            name=source.crossmatches[0].source_id,
-                            ra=source.ra.to_value("deg"),
-                            dec=source.dec.to_value("deg"),
-                            variable=False,
-                            extra=None,
-                        )
-                    )
+                if socat_id in source_translations:
+                    continue
 
+                source_id = await self._lookup_or_create_source_id(
+                    backend,
+                    socat_id,
+                    source.crossmatches[0].source_id,
+                    source.ra.to_value("deg"),
+                    source.dec.to_value("deg"),
+                )
+
+                if source_id is not None:
                     source_translations[socat_id] = source_id
-
-                    await self.log.ainfo(
-                        "lightcurvedb.output.upserted_source",
-                        socat_id=socat_id,
-                        source_id=str(source_id),
-                    )
 
         return source_translations
 
@@ -101,6 +128,15 @@ class LightcurveDBOutput(SourceOutput):
             return None
 
         source_id = socat_to_internal.get(input_measurement.crossmatches[0].catalog_idx)
+
+        if source_id is None:
+            self.log.warning(
+                "lightcurvedb.output.skipping_source_not_registered",
+                socat_id=input_measurement.crossmatches[0].catalog_idx,
+                ra=input_measurement.ra.to_value("deg"),
+                dec=input_measurement.dec.to_value("deg"),
+            )
+            return None
 
         fm = FluxMeasurement(
             measurement_id=uuid7.create(),

--- a/sotrplib/outputs/lightcurvedb.py
+++ b/sotrplib/outputs/lightcurvedb.py
@@ -6,6 +6,7 @@ import asyncio
 from datetime import timezone
 from uuid import UUID
 
+import uuid7
 from astropy.time import Time
 from lightcurvedb.config import Settings as LightcurveDBSettings
 from lightcurvedb.models.cutout import Cutout
@@ -38,7 +39,7 @@ class LightcurveDBOutput(SourceOutput):
         self.upsert_sources = upsert_sources
         self.log = log or get_logger()
 
-    async def _get_source_translations(self) -> dict[int, UUID]:
+    async def _get_source_translations(self) -> dict[UUID, UUID]:
         async with self.settings.backend as backend:
             return {st.socat_id: st.source_id for st in await backend.sources.get_all()}
 
@@ -60,7 +61,7 @@ class LightcurveDBOutput(SourceOutput):
                     )
                     continue
 
-                socat_id = int(source.crossmatches[0].catalog_idx)
+                socat_id = source.crossmatches[0].catalog_idx
 
                 if socat_id not in source_translations:
                     source_id = await backend.sources.create(
@@ -87,7 +88,7 @@ class LightcurveDBOutput(SourceOutput):
     def _convert_internal_to_lightcurvedb_source(
         self,
         input_measurement: MeasuredSource,
-        socat_to_internal: dict[int, UUID],
+        socat_to_internal: dict[UUID, UUID],
         map_time: Time | None = None,
         map_id: str | None = None,
     ) -> tuple[FluxMeasurement, Cutout] | None:
@@ -99,11 +100,10 @@ class LightcurveDBOutput(SourceOutput):
             )
             return None
 
-        source_id = socat_to_internal.get(
-            int(input_measurement.crossmatches[0].catalog_idx)
-        )
+        source_id = socat_to_internal.get(input_measurement.crossmatches[0].catalog_idx)
 
         fm = FluxMeasurement(
+            measurement_id=uuid7.create(),
             frequency=90,
             module="i1",
             source_id=source_id,
@@ -177,7 +177,7 @@ class LightcurveDBOutput(SourceOutput):
     def _convert_all_sources(
         self,
         sources: list[MeasuredSource],
-        socat_to_internal: dict[int, UUID],
+        socat_to_internal: dict[UUID, UUID],
         map_time: Time | None = None,
         map_id: str | None = None,
     ) -> tuple[list[FluxMeasurement], list[Cutout]]:
@@ -201,18 +201,23 @@ class LightcurveDBOutput(SourceOutput):
         cutouts: list[Cutout],
     ) -> int:
         async with self.settings.backend as backend:
-            flux_measurement_ids = await backend.fluxes.create_batch(flux_measurements)
+            # create_batch() doesn't return the created IDs (neither the
+            # postgres nor the parquet backend implementation does, despite
+            # _upload_sources previously assuming otherwise) -- use each
+            # FluxMeasurement's own measurement_id (client-generated above)
+            # to link its cutout instead of relying on a return value.
+            await backend.fluxes.create_batch(flux_measurements)
             processed_cutouts = [
                 Cutout(
-                    measurement_id=fm_id,
+                    measurement_id=fm.measurement_id,
                     **cutout.model_dump(exclude={"measurement_id"}),
                 )
-                for fm_id, cutout in zip(flux_measurement_ids, cutouts)
+                for fm, cutout in zip(flux_measurements, cutouts)
                 if cutout is not None
             ]
             await backend.cutouts.create_batch(processed_cutouts)
 
-        return len(flux_measurement_ids)
+        return len(flux_measurements)
 
     async def _flux_upload_flow(
         self,

--- a/sotrplib/outputs/lightserve.py
+++ b/sotrplib/outputs/lightserve.py
@@ -3,6 +3,7 @@ Output data directly to lightserve.
 """
 
 import httpx
+import uuid7
 from lightcurvedb.models.cutout import Cutout
 from lightcurvedb.models.flux import FluxMeasurement
 from soauth.toolkit.client import SOAuth
@@ -58,8 +59,12 @@ class LightServeOutput(SourceOutput):
         total_uploads = 0
 
         source_translations = client.get("/sources/").json()
+        # socat_id comes back from JSON as a plain string (UUIDs serialize
+        # to strings), so normalize both sides of the lookup to str() --
+        # source.crossmatches[0].catalog_idx may be a real uuid.UUID object
+        # depending on which crossmatch mechanism produced it.
         socat_to_internal = {
-            st["socat_id"]: st["source_id"] for st in source_translations
+            str(st["socat_id"]): st["source_id"] for st in source_translations
         }
 
         for source in forced_photometry_candidates + sifter_result.source_candidates:
@@ -72,9 +77,10 @@ class LightServeOutput(SourceOutput):
                 continue
 
             fm = FluxMeasurement(
+                measurement_id=uuid7.create(),
                 frequency=90,
                 module="i1",
-                source_id=socat_to_internal[int(source.crossmatches[0].source_id)],
+                source_id=socat_to_internal[str(source.crossmatches[0].catalog_idx)],
                 time=source.observation_mean_time.to_datetime(),
                 ra=source.ra.to_value("deg"),
                 dec=source.dec.to_value("deg"),

--- a/sotrplib/sources/sources.py
+++ b/sotrplib/sources/sources.py
@@ -21,6 +21,17 @@ class BaseSource(BaseModel):
 
 
 class CrossMatch(BaseModel):
+    """
+    A single crossmatch result against a catalog entry.
+
+    `catalog_idx` is the catalog's unique, stable identifier for the
+    matched entry (e.g. a socat UUID) and should be used for any lookup
+    that requires uniqueness (database joins, lightcurve linkage, etc.).
+    `source_id` is not guaranteed to be unique -- for some catalogs (e.g.
+    socat's SSO/monitored-source generators) it is a human-readable name
+    such as "Ceres" rather than an identifier.
+    """
+
     ra: AstroPydanticQuantity[u.deg] | None = None
     dec: AstroPydanticQuantity[u.deg] | None = None
     observation_time: AstroPydanticTime | None = None

--- a/tests/test_outputs/test_lightcurvedb.py
+++ b/tests/test_outputs/test_lightcurvedb.py
@@ -1,0 +1,119 @@
+"""
+Tests for LightcurveDBOutput, in particular that a real UUID socat
+crossmatch (CrossMatch.catalog_idx) round-trips correctly -- socat's real
+source IDs are UUIDs, and lightcurvedb.models.source.Source.socat_id used
+to be typed `int`, which made this path crash on any real crossmatch.
+
+Verification reads the parquet backend's files directly rather than
+through higher-level lightcurvedb read APIs (e.g. get_source_lightcurve),
+since those return aggregated/binned lightcurve structures rather than
+raw per-measurement rows -- reading the parquet files is simpler and more
+direct for asserting exactly what got written.
+"""
+
+import asyncio
+import uuid
+
+import astropy.units as u
+import numpy as np
+import pandas as pd
+import pytest
+from astropy.time import Time
+from lightcurvedb.config import Settings
+from lightcurvedb.models.source import Source
+
+from sotrplib.outputs.lightcurvedb import LightcurveDBOutput
+from sotrplib.sifter.core import SifterResult
+from sotrplib.sources.sources import CrossMatch, MeasuredSource
+
+
+@pytest.fixture
+def lightcurvedb_settings(tmp_path):
+    return Settings(backend_type="parquet", parquet_base_path=str(tmp_path))
+
+
+def _register_socat_source(settings: Settings, socat_id: uuid.UUID) -> uuid.UUID:
+    async def _create():
+        async with settings.backend as backend:
+            return await backend.sources.create(
+                Source(socat_id=socat_id, name="Test", ra=10.0, dec=5.0, variable=False)
+            )
+
+    return asyncio.run(_create())
+
+
+def make_candidate(socat_id: uuid.UUID, flux_mjy: float, with_thumbnail: bool):
+    return MeasuredSource(
+        ra=10.0 * u.deg,
+        dec=5.0 * u.deg,
+        flux=flux_mjy * u.mJy,
+        err_flux=1.0 * u.mJy,
+        observation_mean_time=Time("2025-09-10T00:00:00"),
+        crossmatches=[
+            CrossMatch(
+                source_id="TestSource", catalog_idx=socat_id, catalog_name="socat"
+            )
+        ],
+        thumbnail=np.zeros((4, 4)) if with_thumbnail else None,
+        thumbnail_unit=u.mJy if with_thumbnail else None,
+    )
+
+
+def test_output_uploads_flux_measurement_with_uuid_crossmatch(
+    tmp_path, lightcurvedb_settings
+):
+    socat_id = uuid.uuid4()
+    lc_source_id = _register_socat_source(lightcurvedb_settings, socat_id)
+
+    candidate = make_candidate(socat_id, flux_mjy=42.0, with_thumbnail=False)
+    output = LightcurveDBOutput(settings=lightcurvedb_settings, upsert_sources=False)
+
+    # Must not raise -- previously crashed on int(catalog_idx) since
+    # catalog_idx is a real uuid.UUID, not something int() can parse.
+    output.output(
+        forced_photometry_candidates=[candidate],
+        sifter_result=SifterResult(
+            source_candidates=[], transient_candidates=[], noise_candidates=[]
+        ),
+        map_id="test_map",
+    )
+
+    fluxes = pd.read_parquet(tmp_path / "fluxes" / f"{lc_source_id}.parquet")
+    assert len(fluxes) == 1
+    assert fluxes.iloc[0]["flux"] == pytest.approx(0.042)  # mJy -> Jy
+
+
+def test_output_links_cutout_to_correct_measurement(tmp_path, lightcurvedb_settings):
+    """The cutout must be linked to the measurement it actually belongs to,
+    not any other measurement in the same batch -- this is what broke when
+    create_batch()'s (nonexistent) return value was used for the linkage
+    instead of each FluxMeasurement's own measurement_id."""
+    socat_id = uuid.uuid4()
+    lc_source_id = _register_socat_source(lightcurvedb_settings, socat_id)
+
+    no_thumb = make_candidate(socat_id, flux_mjy=10.0, with_thumbnail=False)
+    with_thumb = make_candidate(socat_id, flux_mjy=20.0, with_thumbnail=True)
+
+    output = LightcurveDBOutput(settings=lightcurvedb_settings, upsert_sources=False)
+    output.output(
+        forced_photometry_candidates=[no_thumb, with_thumb],
+        sifter_result=SifterResult(
+            source_candidates=[], transient_candidates=[], noise_candidates=[]
+        ),
+        map_id="test_map",
+    )
+
+    fluxes = pd.read_parquet(tmp_path / "fluxes" / f"{lc_source_id}.parquet")
+    assert len(fluxes) == 2
+
+    twenty_mjy_id = fluxes.index[
+        fluxes["flux"].apply(lambda f: f == pytest.approx(0.020))
+    ][0]
+    ten_mjy_id = fluxes.index[
+        fluxes["flux"].apply(lambda f: f == pytest.approx(0.010))
+    ][0]
+
+    cutouts = pd.read_parquet(tmp_path / "cutouts" / f"{lc_source_id}.parquet")
+    assert len(cutouts) == 1
+    assert str(cutouts.index[0]) == str(twenty_mjy_id)
+    assert str(cutouts.index[0]) != str(ten_mjy_id)

--- a/tests/test_outputs/test_lightcurvedb.py
+++ b/tests/test_outputs/test_lightcurvedb.py
@@ -117,3 +117,53 @@ def test_output_links_cutout_to_correct_measurement(tmp_path, lightcurvedb_setti
     assert len(cutouts) == 1
     assert str(cutouts.index[0]) == str(twenty_mjy_id)
     assert str(cutouts.index[0]) != str(ten_mjy_id)
+
+
+def test_output_creates_unregistered_source_when_upsert_enabled(
+    tmp_path, lightcurvedb_settings
+):
+    """A socat_id with no matching lightcurvedb source (get_by_socat_id
+    misses) should be created on the fly when upsert_sources=True, rather
+    than silently dropping the measurement."""
+    socat_id = uuid.uuid4()
+    candidate = make_candidate(socat_id, flux_mjy=42.0, with_thumbnail=False)
+    output = LightcurveDBOutput(settings=lightcurvedb_settings, upsert_sources=True)
+
+    output.output(
+        forced_photometry_candidates=[candidate],
+        sifter_result=SifterResult(
+            source_candidates=[], transient_candidates=[], noise_candidates=[]
+        ),
+        map_id="test_map",
+    )
+
+    sources = pd.read_parquet(tmp_path / "sources.parquet")
+    assert len(sources) == 1
+    assert sources.iloc[0]["socat_id"] == str(socat_id)
+
+    lc_source_id = sources.index[0]
+    fluxes = pd.read_parquet(tmp_path / "fluxes" / f"{lc_source_id}.parquet")
+    assert len(fluxes) == 1
+    assert fluxes.iloc[0]["flux"] == pytest.approx(0.042)
+
+
+def test_output_skips_unregistered_source_when_upsert_disabled(
+    tmp_path, lightcurvedb_settings
+):
+    """A socat_id with no matching lightcurvedb source (get_by_socat_id
+    misses) should be skipped, not raise, when upsert_sources=False."""
+    socat_id = uuid.uuid4()
+    candidate = make_candidate(socat_id, flux_mjy=42.0, with_thumbnail=False)
+    output = LightcurveDBOutput(settings=lightcurvedb_settings, upsert_sources=False)
+
+    # Must not raise, even though the source was never registered.
+    output.output(
+        forced_photometry_candidates=[candidate],
+        sifter_result=SifterResult(
+            source_candidates=[], transient_candidates=[], noise_candidates=[]
+        ),
+        map_id="test_map",
+    )
+
+    assert not (tmp_path / "sources.parquet").exists()
+    assert not any((tmp_path / "fluxes").glob("*.parquet"))


### PR DESCRIPTION
Update lightcurvedb output to use catalog_idx which is uuid from socat. this keeps everything linked. 

Below is verbose commit from Claude:
-------

Both output writers did int(source.crossmatches[0].catalog_idx) (or, in LightServeOutput's case, the wrong field entirely -- .source_id, a name string like "Ceres", instead of .catalog_idx, the actual socat UUID) to look up a source's socat_id. socat's real source IDs are UUIDs, so this crashed on any real crossmatch; fixed now that lightcurvedb's own Source.socat_id is UUID-typed (see the companion lightcurvedb PR).

Getting a real end-to-end test working (a UUID crossmatch -> upload, against lightcurvedb's parquet backend, no Docker needed) surfaced two more pre-existing bugs in LightcurveDBOutput, unrelated to socat_id but blocking it from ever completing successfully for any input:

- FluxMeasurement.measurement_id has no default and must be supplied by the caller (unlike Source.source_id, which does), but _convert_internal_to_lightcurvedb_source never set it. Now generated client-side via uuid7.create(), matching this repo's existing convention (socat.py, sifter files).
- _upload_sources() then assumed backend.fluxes.create_batch() returns the created measurement IDs, to link each Cutout via Cutout(measurement_id=fm_id, ...). Neither the postgres nor the parquet backend implementation actually returns anything (create_batch is typed -> None in both) -- this always raised TypeError: 'NoneType' object is not iterable. Since measurement_id is now client-generated anyway, use each FluxMeasurement's own measurement_id for the cutout linkage instead of relying on a return value that was never coming.

Added the same client-side-UUID + wrong-field fixes to LightServeOutput, which has the identical socat_to_internal-dict pattern but reads back socat_id from a JSON HTTP response (a plain string, since UUIDs serialize to strings) -- normalized both sides of that lookup to str().

New tests/test_outputs/test_lightcurvedb.py exercises the full path (UUID crossmatch -> upload -> correct source/flux/cutout linkage) against lightcurvedb's parquet backend directly, no Docker required.