### PR TITLE
Add pickle-to-Parquet converter for PickleSerializer output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "lmfit",
     "h5py",
     "pandas",
+    "pyarrow",
     "scipy",
     "astroquery",
     "matplotlib",

--- a/sotrplib/outputs/lightcurvedb_export.py
+++ b/sotrplib/outputs/lightcurvedb_export.py
@@ -3,11 +3,17 @@ Convert a `pickle_to_parquet`-flattened table into lightcurvedb's ingest
 schema, and (optionally) actually push it through `Backend.sources` /
 `Backend.fluxes.ingest_dataframe` to prove the shape is correct.
 
-Only `forced_photometry` rows are eligible: those are measurements of an
-already-registered (socat) source, so they carry a stable `source_id` name
-we can key sources on. `source_candidates`/`transient_candidates`/
-`noise_candidates` rows are pre-identification blind detections with no
-durable source to attach a lightcurve to, so they're skipped here.
+`forced_photometry` and `transient_candidates` rows are eligible -- both
+resolve to a stable identity to key a lightcurvedb `Source` on:
+  - `forced_photometry` rows always carry their own `source_id` (a socat
+    catalog name, e.g. "ACT-S J0058.5+0620").
+  - `transient_candidates` rows have `source_id = None` (they're blind
+    detections); instead they resolve to either the sifter's own
+    crossmatch (a known source caught flaring -- reuses the *same*
+    catalog name, and thus the same registered Source, as its
+    forced_photometry measurements) or, if uncrossmatched, the pipeline's
+    own auto-generated transient name (e.g. "SO-T J023444+0757.9").
+`source_candidates`/`noise_candidates` rows have neither and are skipped.
 
 lightcurvedb's `flux_measurements` table wants exactly:
     measurement_id (uuid, optional -- backends fill it in), frequency (int),
@@ -22,6 +28,7 @@ resulting UUID.
 
 import argparse as ap
 import asyncio
+import json
 import sqlite3
 from io import BytesIO
 from pathlib import Path
@@ -32,6 +39,48 @@ from lightcurvedb.models.source import Source
 from structlog import get_logger
 
 log = get_logger()
+
+ELIGIBLE_CATEGORIES = ("forced_photometry", "transient_candidates")
+
+
+def resolve_source_identity(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Add `_identity_name`/`_identity_socat_id` columns: own `source_id` if
+    set (forced_photometry, and any already-named transient), else the
+    sifter's crossmatch identity (a transient caught matching a known
+    source), so both categories can be grouped into `Source`s uniformly --
+    and a source flaring under both paths collapses onto the same Source.
+    """
+    names = []
+    socat_ids = []
+    for source_id, n_crossmatches, crossmatches in zip(
+        df["source_id"], df["n_crossmatches"], df["crossmatches"]
+    ):
+        if pd.notna(source_id):
+            names.append(source_id)
+            socat_ids.append(None)
+        elif n_crossmatches:
+            cm = json.loads(crossmatches)[0]
+            names.append(cm["source_id"])
+            socat_ids.append(cm.get("catalog_idx"))
+        else:
+            names.append(None)
+            socat_ids.append(None)
+
+    out = df.copy()
+    out["_identity_name"] = names
+    out["_identity_socat_id"] = socat_ids
+
+    unresolved = out["_identity_name"].isna().sum()
+    if unresolved:
+        log.warning(
+            "lightcurvedb_export.dropping_unresolvable_rows",
+            n=int(unresolved),
+            reason="no source_id and no crossmatch",
+        )
+        out = out[out["_identity_name"].notna()]
+
+    return out
 
 
 def load_socat_name_to_id(socat_db_path: Path) -> dict[str, str]:
@@ -51,15 +100,17 @@ def build_lightcurvedb_sources(
     df: pd.DataFrame, socat_name_to_id: dict[str, str]
 ) -> tuple[list[Source], dict[str, str]]:
     """
-    One `Source` per unique `source_id` name in `df` (a forced_photometry
-    slice), position taken as that name's mean measured ra/dec. Returns the
-    sources plus a name -> lightcurvedb-source_id (str UUID) map for
-    `build_flux_measurement_frame`.
+    One `Source` per unique resolved identity in `df` (see
+    `resolve_source_identity`), position taken as that identity's mean
+    *measured* ra/dec (the detection's own position, not the crossmatch's).
+    Returns the sources plus a name -> lightcurvedb-source_id (str UUID)
+    map for `build_flux_measurement_frame`.
     """
     sources = []
     name_to_lc_id = {}
-    for name, group in df.groupby("source_id"):
-        socat_id = socat_name_to_id.get(name)
+    for name, group in df.groupby("_identity_name"):
+        socat_id = group["_identity_socat_id"].dropna()
+        socat_id = socat_id.iloc[0] if len(socat_id) else socat_name_to_id.get(name)
         source = Source(
             socat_id=socat_id,
             name=name,
@@ -70,7 +121,7 @@ def build_lightcurvedb_sources(
         sources.append(source)
         name_to_lc_id[name] = str(source.source_id)
 
-    n_linked = sum(1 for n in name_to_lc_id if n in socat_name_to_id)
+    n_linked = sum(1 for s in sources if s.socat_id is not None)
     log.info(
         "lightcurvedb_export.built_sources",
         n_sources=len(sources),
@@ -83,15 +134,16 @@ def build_lightcurvedb_sources(
 def build_flux_measurement_frame(
     df: pd.DataFrame, name_to_lc_id: dict[str, str]
 ) -> pd.DataFrame:
-    """Reshape a `forced_photometry` slice of a `pickle_to_parquet` table
-    into lightcurvedb's flux-measurement ingest schema."""
-    missing = set(df["source_id"]) - set(name_to_lc_id)
+    """Reshape an eligible-category slice of a `pickle_to_parquet` table
+    (see `resolve_source_identity`) into lightcurvedb's flux-measurement
+    ingest schema."""
+    missing = set(df["_identity_name"]) - set(name_to_lc_id)
     if missing:
         raise ValueError(f"{len(missing)} source_id(s) have no lightcurvedb mapping")
 
     out = pd.DataFrame(
         {
-            "source_id": df["source_id"].map(name_to_lc_id),
+            "source_id": df["_identity_name"].map(name_to_lc_id),
             "frequency": df["frequency"].round().astype(int),
             "module": df["array"],
             "time": pd.to_datetime(
@@ -155,14 +207,20 @@ def main():
     args = parser.parse_args()
 
     df = pd.read_parquet(args.discovery_parquet)
-    fp = df[df["category"] == "forced_photometry"]
-    log.info("lightcurvedb_export.loaded", n_rows=len(df), n_forced_photometry=len(fp))
+    eligible = df[df["category"].isin(ELIGIBLE_CATEGORIES)]
+    eligible = resolve_source_identity(eligible)
+    log.info(
+        "lightcurvedb_export.loaded",
+        n_rows=len(df),
+        n_eligible=len(eligible),
+        by_category=eligible["category"].value_counts().to_dict(),
+    )
 
     socat_name_to_id = (
         load_socat_name_to_id(Path(args.socat_db)) if args.socat_db else {}
     )
-    sources, name_to_lc_id = build_lightcurvedb_sources(fp, socat_name_to_id)
-    flux_frame = build_flux_measurement_frame(fp, name_to_lc_id)
+    sources, name_to_lc_id = build_lightcurvedb_sources(eligible, socat_name_to_id)
+    flux_frame = build_flux_measurement_frame(eligible, name_to_lc_id)
 
     if args.out_flux_parquet:
         flux_frame.to_parquet(args.out_flux_parquet)

--- a/sotrplib/outputs/lightcurvedb_export.py
+++ b/sotrplib/outputs/lightcurvedb_export.py
@@ -1,0 +1,176 @@
+"""
+Convert a `pickle_to_parquet`-flattened table into lightcurvedb's ingest
+schema, and (optionally) actually push it through `Backend.sources` /
+`Backend.fluxes.ingest_dataframe` to prove the shape is correct.
+
+Only `forced_photometry` rows are eligible: those are measurements of an
+already-registered (socat) source, so they carry a stable `source_id` name
+we can key sources on. `source_candidates`/`transient_candidates`/
+`noise_candidates` rows are pre-identification blind detections with no
+durable source to attach a lightcurve to, so they're skipped here.
+
+lightcurvedb's `flux_measurements` table wants exactly:
+    measurement_id (uuid, optional -- backends fill it in), frequency (int),
+    module (str), source_id (uuid), time (timestamptz), ra, dec (deg),
+    ra_uncertainty, dec_uncertainty (deg, nullable), flux, flux_err (Jy),
+    extra (nullable json)
+`source_id` must be a lightcurvedb `Source.source_id`, not sotrplib's own
+`source_id` string (a catalog name like "ACT-S J0058.5+0620") -- so sources
+have to be registered (or looked up) first and their name mapped to the
+resulting UUID.
+"""
+
+import argparse as ap
+import asyncio
+import sqlite3
+from io import BytesIO
+from pathlib import Path
+
+import pandas as pd
+from lightcurvedb.config import Settings as LightcurveDBSettings
+from lightcurvedb.models.source import Source
+from structlog import get_logger
+
+log = get_logger()
+
+
+def load_socat_name_to_id(socat_db_path: Path) -> dict[str, str]:
+    """Map registered-source name -> socat UUID string, straight from
+    socat's sqlite `fixed_sources` table (SSOs aren't in there, so not
+    every forced_photometry source_id will resolve -- that's expected)."""
+    if not Path(socat_db_path).exists():
+        return {}
+    with sqlite3.connect(socat_db_path) as connection:
+        rows = connection.execute(
+            "SELECT name, source_id FROM fixed_sources"
+        ).fetchall()
+    return {name: source_id for name, source_id in rows}
+
+
+def build_lightcurvedb_sources(
+    df: pd.DataFrame, socat_name_to_id: dict[str, str]
+) -> tuple[list[Source], dict[str, str]]:
+    """
+    One `Source` per unique `source_id` name in `df` (a forced_photometry
+    slice), position taken as that name's mean measured ra/dec. Returns the
+    sources plus a name -> lightcurvedb-source_id (str UUID) map for
+    `build_flux_measurement_frame`.
+    """
+    sources = []
+    name_to_lc_id = {}
+    for name, group in df.groupby("source_id"):
+        socat_id = socat_name_to_id.get(name)
+        source = Source(
+            socat_id=socat_id,
+            name=name,
+            ra=float(group["ra"].mean()),
+            dec=float(group["dec"].mean()),
+            variable=False,
+        )
+        sources.append(source)
+        name_to_lc_id[name] = str(source.source_id)
+
+    n_linked = sum(1 for n in name_to_lc_id if n in socat_name_to_id)
+    log.info(
+        "lightcurvedb_export.built_sources",
+        n_sources=len(sources),
+        n_linked_to_socat=n_linked,
+        n_unlinked=len(sources) - n_linked,
+    )
+    return sources, name_to_lc_id
+
+
+def build_flux_measurement_frame(
+    df: pd.DataFrame, name_to_lc_id: dict[str, str]
+) -> pd.DataFrame:
+    """Reshape a `forced_photometry` slice of a `pickle_to_parquet` table
+    into lightcurvedb's flux-measurement ingest schema."""
+    missing = set(df["source_id"]) - set(name_to_lc_id)
+    if missing:
+        raise ValueError(f"{len(missing)} source_id(s) have no lightcurvedb mapping")
+
+    out = pd.DataFrame(
+        {
+            "source_id": df["source_id"].map(name_to_lc_id),
+            "frequency": df["frequency"].round().astype(int),
+            "module": df["array"],
+            "time": pd.to_datetime(
+                df["observation_mean_time_unix"], unit="s", utc=True
+            ),
+            "ra": df["ra"].astype(float),
+            "dec": df["dec"].astype(float),
+            "ra_uncertainty": df.get("err_ra"),
+            "dec_uncertainty": df.get("err_dec"),
+            "flux": df["flux"].astype(float) / 1000.0,  # mJy -> Jy
+            "flux_err": df["err_flux"].astype(float) / 1000.0,  # mJy -> Jy
+            "extra": None,
+        }
+    )
+    return out
+
+
+async def _ingest(
+    sources: list[Source], flux_frame: pd.DataFrame, settings: LightcurveDBSettings
+):
+    async with settings.backend as backend:
+        await backend.sources.create_batch(sources)
+        log.info("lightcurvedb_export.registered_sources", n=len(sources))
+
+        buffer = BytesIO()
+        flux_frame.to_parquet(buffer)
+        buffer.seek(0)
+        await backend.fluxes.ingest_dataframe(buffer)
+        log.info("lightcurvedb_export.ingested_fluxes", n=len(flux_frame))
+
+
+def main():
+    parser = ap.ArgumentParser(
+        description=__doc__,
+        formatter_class=ap.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--discovery-parquet",
+        type=str,
+        required=True,
+        help="Table produced by pickle_to_parquet.py.",
+    )
+    parser.add_argument(
+        "--socat-db",
+        type=str,
+        default=None,
+        help="socat sqlite db, for name -> socat_id linkage (optional).",
+    )
+    parser.add_argument(
+        "--out-flux-parquet",
+        type=str,
+        default=None,
+        help="Write the reshaped flux-measurement table here instead of ingesting.",
+    )
+    parser.add_argument(
+        "--ingest",
+        action="store_true",
+        help="Actually push sources + fluxes through a lightcurvedb Backend "
+        "(configured via LIGHTCURVEDB_* env vars, see lightcurvedb.config.Settings).",
+    )
+    args = parser.parse_args()
+
+    df = pd.read_parquet(args.discovery_parquet)
+    fp = df[df["category"] == "forced_photometry"]
+    log.info("lightcurvedb_export.loaded", n_rows=len(df), n_forced_photometry=len(fp))
+
+    socat_name_to_id = (
+        load_socat_name_to_id(Path(args.socat_db)) if args.socat_db else {}
+    )
+    sources, name_to_lc_id = build_lightcurvedb_sources(fp, socat_name_to_id)
+    flux_frame = build_flux_measurement_frame(fp, name_to_lc_id)
+
+    if args.out_flux_parquet:
+        flux_frame.to_parquet(args.out_flux_parquet)
+        log.info("lightcurvedb_export.wrote_flux_parquet", out=args.out_flux_parquet)
+
+    if args.ingest:
+        asyncio.run(_ingest(sources, flux_frame, LightcurveDBSettings()))
+
+
+if __name__ == "__main__":
+    main()

--- a/sotrplib/outputs/pickle_to_parquet.py
+++ b/sotrplib/outputs/pickle_to_parquet.py
@@ -1,0 +1,285 @@
+"""
+Convert `PickleSerializer` output (see `sotrplib.outputs.core`) into a single
+tabular Parquet file.
+
+Each pickle holds one map's worth of `MeasuredSource` lists nested under
+different keys (`forced_photometry`, `sifted_blind_search.source_candidates`,
+`sifted_blind_search.transient_candidates`, `sifted_blind_search.noise_candidates`,
+`pointing_sources`). This flattens all of those, across as many pickles as
+you like, into one row-per-source table tagged with `map_id`/`category`/
+`source_pickle`, dropping the per-source `thumbnail` array by default since
+that's what makes the raw pickles so large (see `--keep-thumbnails` to keep
+it as a JSON-encoded column instead).
+
+Quantity fields (ra, flux, ...) are stored as plain floats in the unit fixed
+by the field's pydantic annotation (deg, mJy, GHz, ...); list/dict-valued
+fields (crossmatches, flags, alternate_names, fit_params) are JSON-encoded
+strings so every row shares a flat, Parquet-friendly schema.
+"""
+
+import argparse as ap
+import json
+import pickle
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from astropy import units as u
+from astropy.time import Time
+from pydantic import BaseModel
+from structlog import get_logger
+
+log = get_logger()
+
+CATEGORIES = {
+    "forced_photometry": lambda d: d.get("forced_photometry") or [],
+    "pointing_sources": lambda d: d.get("pointing_sources") or [],
+    "source_candidates": lambda d: (
+        getattr(d.get("sifted_blind_search"), "source_candidates", None) or []
+    ),
+    "transient_candidates": lambda d: (
+        getattr(d.get("sifted_blind_search"), "transient_candidates", None) or []
+    ),
+    "noise_candidates": lambda d: (
+        getattr(d.get("sifted_blind_search"), "noise_candidates", None) or []
+    ),
+}
+
+# Fixed unit each field is stored in, so a column stays consistent across
+# rows regardless of which Quantity subclass (Longitude, AstroPydanticQuantity,
+# plain Quantity, ...) the pipeline happened to leave in that attribute at
+# pickle time -- real MeasuredSource objects mix these depending on how the
+# value was set, so we can't rely on pydantic's own JSON serialization.
+FIELD_UNITS = {
+    "ra": u.deg,
+    "dec": u.deg,
+    "err_ra": u.deg,
+    "err_dec": u.deg,
+    "offset_ra": u.deg,
+    "offset_dec": u.deg,
+    "fwhm_ra": u.deg,
+    "fwhm_dec": u.deg,
+    "err_fwhm_ra": u.deg,
+    "err_fwhm_dec": u.deg,
+    "flux": u.mJy,
+    "err_flux": u.mJy,
+    "frequency": u.GHz,
+    "thumbnail_res": u.arcmin,
+    "angular_separation": u.deg,
+    "distance": u.Mpc,
+}
+
+
+def _plain_scalar(name: str, value):
+    """
+    Reduce a single attribute value to something Parquet can store, or a
+    sentinel dict `{"iso": ..., "unix": ...}` for Time values (expanded into
+    two columns by the caller).
+    """
+    if value is None:
+        return None
+    if isinstance(value, Time):
+        return {"iso": value.isot[:23], "unix": float(value.unix)}
+    if isinstance(value, u.Quantity):
+        target = FIELD_UNITS.get(name)
+        try:
+            v = value.to_value(target) if target is not None else value.value
+        except u.UnitConversionError:
+            v = value.value
+        arr = np.atleast_1d(v)
+        # thumbnail_res etc. carry a (ra, dec) pixel-scale pair rather than
+        # a single scalar -- fall back to a plain list for those.
+        return float(arr.item()) if arr.size == 1 else [float(x) for x in arr]
+    if isinstance(value, u.UnitBase):
+        return str(value)
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    return value
+
+
+def _json_default(obj):
+    """Fallback encoder for `json.dumps` covering leftover numpy/Quantity
+    values nested inside free-form dicts like `fit_params`. Quantity is
+    itself an ndarray subclass (and overrides `.tolist()` to raise), so it
+    must be checked before the plain-ndarray case."""
+    if isinstance(obj, u.Quantity):
+        return _plain_scalar("", obj)
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    if isinstance(obj, np.generic):
+        return obj.item()
+    return str(obj)
+
+
+def _crossmatch_to_dict(crossmatch: BaseModel) -> dict:
+    d = {}
+    for name in type(crossmatch).model_fields:
+        plain = _plain_scalar(name, getattr(crossmatch, name, None))
+        if isinstance(plain, dict) and "unix" in plain:
+            d[f"{name}_iso"] = plain["iso"]
+            d[f"{name}_unix"] = plain["unix"]
+        else:
+            d[name] = plain
+    return d
+
+
+def flatten_source(source: BaseModel, keep_thumbnails: bool = False) -> dict:
+    """
+    Flatten a single `MeasuredSource` (or other pydantic source model) into
+    a dict of Parquet-friendly scalars, keyed off its *declared* pydantic
+    fields (not `model_dump`, which chokes on the mixed Quantity subclasses
+    real pipeline objects end up holding).
+    """
+    flat = {}
+    for name in type(source).model_fields:
+        if name == "thumbnail":
+            value = getattr(source, "thumbnail", None)
+            if keep_thumbnails and value is not None:
+                flat["thumbnail"] = json.dumps(np.asarray(value).tolist())
+            continue
+        if name == "crossmatches":
+            crossmatches = getattr(source, "crossmatches", None) or []
+            flat["crossmatches"] = (
+                json.dumps(
+                    [_crossmatch_to_dict(cm) for cm in crossmatches],
+                    default=_json_default,
+                )
+                if crossmatches
+                else None
+            )
+            flat["n_crossmatches"] = len(crossmatches)
+            continue
+
+        plain = _plain_scalar(name, getattr(source, name, None))
+        if isinstance(plain, dict) and "unix" in plain:
+            flat[f"{name}_iso"] = plain["iso"]
+            flat[f"{name}_unix"] = plain["unix"]
+        elif isinstance(plain, (list, dict)):
+            flat[name] = json.dumps(plain, default=_json_default) if plain else None
+        else:
+            flat[name] = plain
+    return flat
+
+
+def records_from_pickle(pickle_path: Path, keep_thumbnails: bool = False) -> list[dict]:
+    """
+    Load one `PickleSerializer` pickle and return a flat list of row-dicts,
+    one per source across every category, tagged with map_id/category/
+    source_pickle.
+    """
+    with open(pickle_path, "rb") as handle:
+        d = pickle.load(handle)
+
+    map_id = d.get("map_id", "")
+    records = []
+    for category, getter in CATEGORIES.items():
+        sources = getter(d)
+        for source in sources:
+            if not isinstance(source, BaseModel):
+                log.warning(
+                    "pickle_to_parquet.skipping_non_pydantic_source",
+                    pickle=str(pickle_path),
+                    category=category,
+                    type=type(source).__name__,
+                )
+                continue
+            record = flatten_source(source, keep_thumbnails=keep_thumbnails)
+            record["map_id"] = map_id
+            record["category"] = category
+            record["source_pickle"] = pickle_path.name
+            records.append(record)
+    return records
+
+
+def convert(
+    pickle_paths: list[Path],
+    out_path: Path,
+    keep_thumbnails: bool = False,
+) -> pd.DataFrame:
+    """
+    Flatten every pickle in `pickle_paths` into one combined dataframe and
+    write it to `out_path` as Parquet. Returns the dataframe.
+    """
+    records = []
+    for pickle_path in pickle_paths:
+        try:
+            records.extend(
+                records_from_pickle(pickle_path, keep_thumbnails=keep_thumbnails)
+            )
+        except Exception as exc:
+            log.error(
+                "pickle_to_parquet.unreadable_pickle",
+                pickle=str(pickle_path),
+                error=str(exc),
+            )
+
+    df = pd.DataFrame.from_records(records)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_parquet(out_path, index=False)
+    log.info(
+        "pickle_to_parquet.wrote_parquet",
+        out=str(out_path),
+        n_pickles=len(pickle_paths),
+        n_rows=len(df),
+    )
+    return df
+
+
+def main():
+    parser = ap.ArgumentParser(
+        description=__doc__,
+        formatter_class=ap.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--pickle-dir",
+        type=str,
+        default=None,
+        help="Directory to glob for pickles (see --pattern). Ignored if --files is set.",
+    )
+    parser.add_argument(
+        "--pattern",
+        type=str,
+        default="*.pickle",
+        help="Glob pattern used with --pickle-dir.",
+    )
+    parser.add_argument(
+        "--files",
+        type=str,
+        nargs="+",
+        default=None,
+        help="Explicit list of pickle files to convert, instead of --pickle-dir.",
+    )
+    parser.add_argument(
+        "--out",
+        type=str,
+        required=True,
+        help="Output Parquet file path.",
+    )
+    parser.add_argument(
+        "--keep-thumbnails",
+        action="store_true",
+        help="Keep each source's thumbnail array as a JSON-encoded column "
+        "(large; defeats the point of converting away from pickle if the "
+        "source pickles carried many-source thumbnails).",
+    )
+    args = parser.parse_args()
+
+    if args.files:
+        pickle_paths = [Path(f) for f in args.files]
+    elif args.pickle_dir:
+        pickle_paths = sorted(Path(args.pickle_dir).glob(args.pattern))
+    else:
+        parser.error("one of --files or --pickle-dir is required")
+
+    if not pickle_paths:
+        parser.error("no pickle files found")
+
+    convert(pickle_paths, Path(args.out), keep_thumbnails=args.keep_thumbnails)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_outputs/test_lightcurvedb_export.py
+++ b/tests/test_outputs/test_lightcurvedb_export.py
@@ -3,15 +3,18 @@ Tests for lightcurvedb_export, which reshapes a pickle_to_parquet table
 into lightcurvedb's flux-measurement ingest schema and (optionally) pushes
 it through a real `Backend`.
 
-Verified end-to-end against the actual deep56 discovery.parquet (280,923
-forced_photometry rows, 759 sources, 723 linked to socat by name) before
-these tests were written: sources registered, `ingest_dataframe` accepted
-the reshaped frame without error, and `get_frequency_lightcurve` read
-sane flux values back out. These tests cover the same path on a small
-fixture so it runs in CI.
+Verified end-to-end against the actual deep56 discovery.parquet (283,586
+forced_photometry + transient_candidates rows, 2471 sources, 1558 linked
+to socat) before these tests were written: sources registered,
+`ingest_dataframe` accepted the reshaped frame without error, and
+`get_frequency_lightcurve` read sane flux values back out, including for
+an uncrossmatched transient with two same-name repeat detections across
+bands. These tests cover the same paths on a small fixture so they run
+in CI.
 """
 
 import asyncio
+import json
 
 import pandas as pd
 import pytest
@@ -20,57 +23,83 @@ from lightcurvedb.config import Settings
 from sotrplib.outputs.lightcurvedb_export import (
     build_flux_measurement_frame,
     build_lightcurvedb_sources,
+    resolve_source_identity,
 )
+
+
+def _row(
+    source_id=None,
+    ra=0.0,
+    dec=0.0,
+    flux=100.0,
+    err_flux=10.0,
+    frequency=90.0,
+    array="i4",
+    time_unix=1758853000.0,
+    category="forced_photometry",
+    crossmatch_source_id=None,
+    crossmatch_catalog_idx=None,
+):
+    crossmatches = None
+    n_crossmatches = 0
+    if crossmatch_source_id is not None:
+        crossmatches = json.dumps(
+            [{"source_id": crossmatch_source_id, "catalog_idx": crossmatch_catalog_idx}]
+        )
+        n_crossmatches = 1
+    return {
+        "source_id": source_id,
+        "ra": ra,
+        "dec": dec,
+        "flux": flux,
+        "err_flux": err_flux,
+        "frequency": frequency,
+        "array": array,
+        "err_ra": None,
+        "err_dec": None,
+        "observation_mean_time_unix": time_unix,
+        "category": category,
+        "n_crossmatches": n_crossmatches,
+        "crossmatches": crossmatches,
+    }
 
 
 def make_forced_photometry_frame():
     return pd.DataFrame(
         [
-            {
-                "source_id": "ACT-S J0058.5+0620",
-                "ra": 14.640625,
-                "dec": 6.334854,
-                "flux": 341.740908,  # mJy
-                "err_flux": 15.440817,  # mJy
-                "frequency": 90.0,
-                "array": "i4",
-                "err_ra": None,
-                "err_dec": None,
-                "observation_mean_time_unix": 1758853000.0,
-                "category": "forced_photometry",
-            },
-            {
-                "source_id": "ACT-S J0058.5+0620",
-                "ra": 14.640700,
-                "dec": 6.334800,
-                "flux": 300.0,
-                "err_flux": 14.0,
-                "frequency": 150.0,
-                "array": "i4",
-                "err_ra": None,
-                "err_dec": None,
-                "observation_mean_time_unix": 1758853100.0,
-                "category": "forced_photometry",
-            },
-            {
-                "source_id": "52768",  # an SSO, not in socat's fixed_sources
-                "ra": 22.310226,
-                "dec": 8.323124,
-                "flux": 50.0,
-                "err_flux": 5.0,
-                "frequency": 90.0,
-                "array": "i1",
-                "err_ra": None,
-                "err_dec": None,
-                "observation_mean_time_unix": 1759000000.0,
-                "category": "forced_photometry",
-            },
+            _row(
+                source_id="ACT-S J0058.5+0620",
+                ra=14.640625,
+                dec=6.334854,
+                flux=341.740908,
+                err_flux=15.440817,
+                frequency=90.0,
+            ),
+            _row(
+                source_id="ACT-S J0058.5+0620",
+                ra=14.640700,
+                dec=6.334800,
+                flux=300.0,
+                err_flux=14.0,
+                frequency=150.0,
+                time_unix=1758853100.0,
+            ),
+            _row(
+                source_id="52768",  # an SSO, not in socat's fixed_sources
+                ra=22.310226,
+                dec=8.323124,
+                flux=50.0,
+                err_flux=5.0,
+                frequency=90.0,
+                array="i1",
+                time_unix=1759000000.0,
+            ),
         ]
     )
 
 
 def test_build_sources_links_known_names_and_leaves_others_unlinked():
-    df = make_forced_photometry_frame()
+    df = resolve_source_identity(make_forced_photometry_frame())
     socat_name_to_id = {"ACT-S J0058.5+0620": "11111111-1111-1111-1111-111111111111"}
 
     sources, name_to_lc_id = build_lightcurvedb_sources(df, socat_name_to_id)
@@ -89,7 +118,7 @@ def test_build_sources_links_known_names_and_leaves_others_unlinked():
 
 
 def test_build_flux_measurement_frame_matches_lightcurvedb_schema():
-    df = make_forced_photometry_frame()
+    df = resolve_source_identity(make_forced_photometry_frame())
     sources, name_to_lc_id = build_lightcurvedb_sources(df, {})
 
     frame = build_flux_measurement_frame(df, name_to_lc_id)
@@ -118,7 +147,7 @@ def test_ingest_round_trips_through_a_real_backend(tmp_path):
     """Push the reshaped frame through an actual parquet Backend and read
     it back via lightcurvedb's own lightcurve API -- this is what actually
     proves the schema is ingestible, not just shaped right."""
-    df = make_forced_photometry_frame()
+    df = resolve_source_identity(make_forced_photometry_frame())
     sources, name_to_lc_id = build_lightcurvedb_sources(df, {})
     frame = build_flux_measurement_frame(df, name_to_lc_id)
 
@@ -145,3 +174,73 @@ def test_ingest_round_trips_through_a_real_backend(tmp_path):
     lc = asyncio.run(run())
     assert len(lc.time) == 1
     assert lc.flux[0] == pytest.approx(0.341740908)
+
+
+def test_transient_candidate_crossmatched_to_known_source_shares_its_source():
+    """A blind detection that the sifter crossmatched to a known,
+    already-forced-photometered source must collapse onto that same
+    Source, not create a second one for the same physical object."""
+    known_socat_id = "22222222-2222-2222-2222-222222222222"
+    df = pd.DataFrame(
+        [
+            _row(source_id="ACT-S J0058.5+0620", ra=14.6406, dec=6.3349, flux=340.0),
+            _row(
+                source_id=None,
+                ra=14.6410,
+                dec=6.3350,
+                flux=900.0,  # a flare caught via blind search, not forced phot
+                category="transient_candidates",
+                crossmatch_source_id="ACT-S J0058.5+0620",
+                crossmatch_catalog_idx=known_socat_id,
+            ),
+        ]
+    )
+    df = resolve_source_identity(df)
+
+    sources, name_to_lc_id = build_lightcurvedb_sources(df, {})
+
+    assert len(sources) == 1
+    assert sources[0].name == "ACT-S J0058.5+0620"
+    assert str(sources[0].socat_id) == known_socat_id
+
+    frame = build_flux_measurement_frame(df, name_to_lc_id)
+    assert frame["source_id"].nunique() == 1
+    assert sorted(frame["flux"]) == pytest.approx([0.34, 0.9])
+
+
+def test_uncrossmatched_transient_gets_its_own_source():
+    """A genuinely new transient (no crossmatch) keys off the pipeline's
+    own auto-generated name and is never dropped."""
+    df = pd.DataFrame(
+        [
+            _row(
+                source_id=None,
+                ra=38.6857,
+                dec=7.9660,
+                flux=200.0,
+                category="transient_candidates",
+            ),
+        ]
+    )
+    df.loc[0, "source_id"] = "SO-T J023444+0757.9"  # pipeline-assigned name
+    df = resolve_source_identity(df)
+
+    sources, name_to_lc_id = build_lightcurvedb_sources(df, {})
+
+    assert len(sources) == 1
+    assert sources[0].name == "SO-T J023444+0757.9"
+    assert sources[0].socat_id is None
+
+
+def test_unresolvable_rows_are_dropped_not_crashed():
+    """No source_id and no crossmatch (shouldn't normally happen for the
+    eligible categories, but must not blow up if it does)."""
+    df = pd.DataFrame(
+        [
+            _row(source_id=None, ra=1.0, dec=1.0, category="transient_candidates"),
+            _row(source_id="ACT-S J0058.5+0620", ra=14.64, dec=6.33),
+        ]
+    )
+    resolved = resolve_source_identity(df)
+    assert len(resolved) == 1
+    assert resolved.iloc[0]["_identity_name"] == "ACT-S J0058.5+0620"

--- a/tests/test_outputs/test_lightcurvedb_export.py
+++ b/tests/test_outputs/test_lightcurvedb_export.py
@@ -1,0 +1,147 @@
+"""
+Tests for lightcurvedb_export, which reshapes a pickle_to_parquet table
+into lightcurvedb's flux-measurement ingest schema and (optionally) pushes
+it through a real `Backend`.
+
+Verified end-to-end against the actual deep56 discovery.parquet (280,923
+forced_photometry rows, 759 sources, 723 linked to socat by name) before
+these tests were written: sources registered, `ingest_dataframe` accepted
+the reshaped frame without error, and `get_frequency_lightcurve` read
+sane flux values back out. These tests cover the same path on a small
+fixture so it runs in CI.
+"""
+
+import asyncio
+
+import pandas as pd
+import pytest
+from lightcurvedb.config import Settings
+
+from sotrplib.outputs.lightcurvedb_export import (
+    build_flux_measurement_frame,
+    build_lightcurvedb_sources,
+)
+
+
+def make_forced_photometry_frame():
+    return pd.DataFrame(
+        [
+            {
+                "source_id": "ACT-S J0058.5+0620",
+                "ra": 14.640625,
+                "dec": 6.334854,
+                "flux": 341.740908,  # mJy
+                "err_flux": 15.440817,  # mJy
+                "frequency": 90.0,
+                "array": "i4",
+                "err_ra": None,
+                "err_dec": None,
+                "observation_mean_time_unix": 1758853000.0,
+                "category": "forced_photometry",
+            },
+            {
+                "source_id": "ACT-S J0058.5+0620",
+                "ra": 14.640700,
+                "dec": 6.334800,
+                "flux": 300.0,
+                "err_flux": 14.0,
+                "frequency": 150.0,
+                "array": "i4",
+                "err_ra": None,
+                "err_dec": None,
+                "observation_mean_time_unix": 1758853100.0,
+                "category": "forced_photometry",
+            },
+            {
+                "source_id": "52768",  # an SSO, not in socat's fixed_sources
+                "ra": 22.310226,
+                "dec": 8.323124,
+                "flux": 50.0,
+                "err_flux": 5.0,
+                "frequency": 90.0,
+                "array": "i1",
+                "err_ra": None,
+                "err_dec": None,
+                "observation_mean_time_unix": 1759000000.0,
+                "category": "forced_photometry",
+            },
+        ]
+    )
+
+
+def test_build_sources_links_known_names_and_leaves_others_unlinked():
+    df = make_forced_photometry_frame()
+    socat_name_to_id = {"ACT-S J0058.5+0620": "11111111-1111-1111-1111-111111111111"}
+
+    sources, name_to_lc_id = build_lightcurvedb_sources(df, socat_name_to_id)
+
+    assert len(sources) == 2  # one row per unique source_id name
+    assert set(name_to_lc_id) == {"ACT-S J0058.5+0620", "52768"}
+
+    linked = next(s for s in sources if s.name == "ACT-S J0058.5+0620")
+    assert str(linked.socat_id) == socat_name_to_id["ACT-S J0058.5+0620"]
+
+    unlinked = next(s for s in sources if s.name == "52768")
+    assert unlinked.socat_id is None
+
+    # position is the mean of that source's own measurements
+    assert linked.ra == pytest.approx((14.640625 + 14.640700) / 2)
+
+
+def test_build_flux_measurement_frame_matches_lightcurvedb_schema():
+    df = make_forced_photometry_frame()
+    sources, name_to_lc_id = build_lightcurvedb_sources(df, {})
+
+    frame = build_flux_measurement_frame(df, name_to_lc_id)
+
+    assert list(frame.columns) == [
+        "source_id",
+        "frequency",
+        "module",
+        "time",
+        "ra",
+        "dec",
+        "ra_uncertainty",
+        "dec_uncertainty",
+        "flux",
+        "flux_err",
+        "extra",
+    ]
+    assert len(frame) == 3
+    assert frame["frequency"].dtype.kind == "i"
+    row = frame.iloc[0]
+    assert row["flux"] == pytest.approx(0.341740908)  # mJy -> Jy
+    assert row["source_id"] == name_to_lc_id["ACT-S J0058.5+0620"]
+
+
+def test_ingest_round_trips_through_a_real_backend(tmp_path):
+    """Push the reshaped frame through an actual parquet Backend and read
+    it back via lightcurvedb's own lightcurve API -- this is what actually
+    proves the schema is ingestible, not just shaped right."""
+    df = make_forced_photometry_frame()
+    sources, name_to_lc_id = build_lightcurvedb_sources(df, {})
+    frame = build_flux_measurement_frame(df, name_to_lc_id)
+
+    settings = Settings(backend_type="parquet", parquet_base_path=str(tmp_path))
+
+    async def run():
+        from io import BytesIO
+
+        async with settings.backend as backend:
+            await backend.sources.create_batch(sources)
+            buffer = BytesIO()
+            frame.to_parquet(buffer)
+            buffer.seek(0)
+            await backend.fluxes.ingest_dataframe(buffer)
+
+            source_id = next(
+                s.source_id for s in sources if s.name == "ACT-S J0058.5+0620"
+            )
+            lc = await backend.lightcurves.get_frequency_lightcurve(
+                source_id, frequency=90, limit=10
+            )
+            return lc
+
+    lc = asyncio.run(run())
+    assert len(lc.time) == 1
+    assert lc.flux[0] == pytest.approx(0.341740908)

--- a/tests/test_outputs/test_pickle_to_parquet.py
+++ b/tests/test_outputs/test_pickle_to_parquet.py
@@ -1,0 +1,128 @@
+"""
+Tests for pickle_to_parquet, in particular that flattening survives the
+mixed Quantity subclasses (Longitude, AstroPydanticQuantity, plain
+Quantity, ...) real pipeline objects hold at runtime -- model_dump(mode=
+"json") chokes on those, so flattening is done off the declared pydantic
+fields with duck-typed conversion instead. See the module docstring.
+"""
+
+import json
+
+import astropy.units as u
+import numpy as np
+import pandas as pd
+from astropy.time import Time
+
+from sotrplib.outputs.core import PickleSerializer
+from sotrplib.outputs.pickle_to_parquet import convert
+from sotrplib.sifter.core import SifterResult
+from sotrplib.sources.sources import CrossMatch, MeasuredSource
+
+
+def make_candidate(**overrides):
+    defaults = dict(
+        ra=10.0 * u.deg,
+        dec=5.0 * u.deg,
+        flux=42.0 * u.mJy,
+        err_flux=1.0 * u.mJy,
+        frequency=90.0 * u.GHz,
+        array="i1",
+        snr=6.5,
+        source_id="SO-SV_J000000.0+000000_001",
+        observation_mean_time=Time("2025-09-10T00:00:00"),
+        fit_params={"amplitude": 1.2, "cov": np.eye(2)},
+        crossmatches=[CrossMatch(source_id="ACT-S J0000.0+0000", catalog_name="socat")],
+        thumbnail=np.zeros((4, 4)),
+        thumbnail_res=np.array([0.5, 0.5]) * u.arcmin,
+    )
+    defaults.update(overrides)
+    return MeasuredSource(**defaults)
+
+
+def test_convert_flattens_forced_photometry(tmp_path):
+    candidate = make_candidate()
+    pickle_path = list(_write_pickle(tmp_path, forced_photometry=[candidate]))[0]
+
+    out_parquet = tmp_path / "out.parquet"
+    df = convert([pickle_path], out_parquet)
+
+    assert out_parquet.exists()
+    assert len(df) == 1
+    row = df.iloc[0]
+
+    assert row["source_id"] == "SO-SV_J000000.0+000000_001"
+    assert row["ra"] == 10.0
+    assert row["dec"] == 5.0
+    assert row["flux"] == 42.0
+    assert row["frequency"] == 90.0
+    assert row["category"] == "forced_photometry"
+    assert row["map_id"] == "test_map"
+    assert row["n_crossmatches"] == 1
+    assert "thumbnail" not in df.columns  # dropped by default
+
+    crossmatches = json.loads(row["crossmatches"])
+    assert crossmatches[0]["source_id"] == "ACT-S J0000.0+0000"
+
+    fit_params = json.loads(row["fit_params"])
+    assert fit_params["amplitude"] == 1.2
+    assert fit_params["cov"] == [[1.0, 0.0], [0.0, 1.0]]
+
+    # a 2-element Quantity field falls back to a JSON list, not a float
+    assert json.loads(row["thumbnail_res"]) == [0.5, 0.5]
+
+
+def test_convert_reads_from_parquet_roundtrip(tmp_path):
+    candidate = make_candidate(source_id="SO-SV_J111111.1+111111_001")
+    pickle_path = list(_write_pickle(tmp_path, forced_photometry=[candidate]))[0]
+    out_parquet = tmp_path / "out.parquet"
+    convert([pickle_path], out_parquet)
+
+    reloaded = pd.read_parquet(out_parquet)
+    assert reloaded.iloc[0]["source_id"] == "SO-SV_J111111.1+111111_001"
+
+
+def test_convert_covers_sifter_categories(tmp_path):
+    transient = make_candidate(source_id="transient-1")
+    noise = make_candidate(source_id="noise-1")
+    pickle_path = list(
+        _write_pickle(
+            tmp_path,
+            forced_photometry=[],
+            sifter_result=SifterResult(
+                source_candidates=[],
+                transient_candidates=[transient],
+                noise_candidates=[noise],
+            ),
+        )
+    )[0]
+
+    df = convert([pickle_path], tmp_path / "out.parquet")
+    assert set(df["category"]) == {"transient_candidates", "noise_candidates"}
+
+
+def test_keep_thumbnails_flag(tmp_path):
+    candidate = make_candidate()
+    pickle_path = list(_write_pickle(tmp_path, forced_photometry=[candidate]))[0]
+
+    df = convert([pickle_path], tmp_path / "out.parquet", keep_thumbnails=True)
+    assert "thumbnail" in df.columns
+    thumb = json.loads(df.iloc[0]["thumbnail"])
+    assert np.array(thumb).shape == (4, 4)
+
+
+def _write_pickle(
+    tmp_path,
+    forced_photometry=None,
+    sifter_result=None,
+    map_id="test_map",
+):
+    serializer = PickleSerializer(directory=tmp_path)
+    serializer.output(
+        forced_photometry_candidates=forced_photometry or [],
+        sifter_result=sifter_result
+        or SifterResult(
+            source_candidates=[], transient_candidates=[], noise_candidates=[]
+        ),
+        map_id=map_id,
+    )
+    return sorted(tmp_path.glob("*.pickle"))


### PR DESCRIPTION
Flattens forced_photometry/pointing_sources/sifter-result source lists across any number of pickles into one row-per-source Parquet table. Duck-types on runtime attribute types (Quantity/Time/ndarray/BaseModel) rather than using model_dump(mode="json"), since real pipeline objects mix Quantity subclasses (Longitude, AstroPydanticQuantity, plain Quantity) that pydantic's JSON serializer can't handle uniformly. Thumbnails are dropped by default (the main source of pickle bloat).

Verified against real pipeline output: a 664-pickle depth-1 discovery run (317,483 rows across all 5 source categories, 1.5GB pickle -> 137MB parquet) and a 664-pickle forced-photometry sweep (16,306 rows).