### PR TITLE
Pin ruff-action to 0.12.5 to match pre-commit's ruff version

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -6,3 +6,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v3
+        with:
+          version: 0.12.5


### PR DESCRIPTION
astral-sh/ruff-action@v3 floats to the latest ruff release by default. ruff 0.16.0 enables new default rules (UP031, PLW1510, ...) that flag pre-existing code across the repo, breaking CI on every PR/push even though nothing changed. Pin to the same version already used by .pre-commit-config.yaml so CI and local pre-commit agree.